### PR TITLE
fix: resolve relative imports in transformed scripts

### DIFF
--- a/examples/src/greeting.ts
+++ b/examples/src/greeting.ts
@@ -10,20 +10,8 @@
 
 import { Agent } from "thinkwell:agent";
 import { CLAUDE_CODE } from "thinkwell:connectors";
-
-function startSpinner(message: string): () => void {
-  const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-  let i = 0;
-  const interval = setInterval(() => {
-    // ANSI escape codes for gray text
-    process.stdout.write(`\r\x1b[90m${frames[i++ % frames.length]} ${message}\x1b[0m`);
-  }, 80);
-
-  return () => {
-    clearInterval(interval);
-    process.stdout.write('\r\x1b[K');
-  };
-}
+import { styleText } from 'node:util';
+import { startSpinner } from "./util/spinner.js";
 
 /**
  * A friendly greeting.
@@ -64,8 +52,7 @@ async function main() {
       .run();
 
     stopSpinner();
-    // ANSI bold white
-    console.log(`\x1b[1;97m✨ ${greeting.message}\x1b[0m`);
+    console.log(styleText(["bold", "white"], `✨ ${greeting.message}`));
   } finally {
     agent.close();
   }

--- a/examples/src/util/spinner.ts
+++ b/examples/src/util/spinner.ts
@@ -1,0 +1,16 @@
+import { styleText } from 'node:util';
+
+const CLEAR = '\r\x1b[K';
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export function startSpinner(message: string): () => void {
+  let i = 0;
+  const interval = setInterval(() => {
+    process.stdout.write(`\r${styleText("gray", `${FRAMES[i++ % FRAMES.length]} ${message}`)}`);
+  }, 80);
+
+  return () => {
+    clearInterval(interval);
+    process.stdout.write(CLEAR);
+  };
+}


### PR DESCRIPTION
## Summary

- Fixed transformed scripts failing to resolve relative imports (e.g., `./util/spinner.js`) because the temp file was written to `os.tmpdir()` instead of alongside the original script
- Added `.js` → `.ts` extension rewriting for relative imports, since Node's `--experimental-transform-types` doesn't perform the remapping that TypeScript convention relies on
- Refactored the greeting example to extract the spinner into a reusable `util/spinner.ts` module (this is what surfaced the bug)

## Test plan

- [x] `pnpm greeting` from `examples/` runs successfully with the spinner working
- [x] Temp file is cleaned up after execution
- [x] Existing test suite passes (70/71; the 1 failure is a pre-existing stale compiled binary version test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)