### PR TITLE
fix(conductor): handle `kiro-cli acp` not exiting on stdin EOF

### DIFF
--- a/doc/workarounds.md
+++ b/doc/workarounds.md
@@ -58,6 +58,32 @@ The custom spinner in [packages/thinkwell/src/cli/build.ts](../packages/thinkwel
 
 ---
 
+## kiro-cli acp: Doesn't Exit on stdin EOF
+
+**Issue:** `kiro-cli acp` (v1.25.0) doesn't exit when stdin closes (EOF). This is a bug in kiro-cli that has been confirmed with the maintainers.
+
+**Expected behavior:** When stdin closes, the process should detect EOF and exit gracefully.
+
+**Actual behavior:** The process continues running indefinitely even after stdin is closed.
+
+**Workaround:** In `packages/conductor/src/connectors/stdio.ts`, we:
+1. Close stdin with `process.stdin.end()`
+2. Wait 250ms for graceful exit
+3. Send SIGTERM if the process hasn't exited
+4. Wait another 500ms
+5. Send SIGKILL if still running
+
+**Side effects:**
+- Process exits with code 255 (from SIGTERM) instead of 0
+- We suppress logging of non-zero exit codes during graceful shutdown to avoid confusing users
+
+**Files affected:**
+- `packages/conductor/src/connectors/stdio.ts` - Timeout logic and exit code logging
+
+**Tracking:** This workaround can be removed once kiro-cli properly handles stdin EOF.
+
+---
+
 ## Historical Workarounds (No Longer In Use)
 
 The following workarounds were used when thinkwell was built on Bun. The project has since migrated to Node.js with pkg for binary distribution. These are preserved for reference.

--- a/examples/src/greeting.ts
+++ b/examples/src/greeting.ts
@@ -53,8 +53,11 @@ async function main() {
 
     stopSpinner();
     console.log(styleText(["bold", "white"], `✨ ${greeting.message}`));
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
   } finally {
-    agent.close();
+    await agent.close();
   }
 }
 

--- a/examples/src/sentiment.ts
+++ b/examples/src/sentiment.ts
@@ -112,7 +112,7 @@ async function main() {
     }
     console.log(`Recommendation: ${analysis.recommendation}`);
   } finally {
-    agent.close();
+    await agent.close();
   }
 }
 

--- a/examples/src/summarize.ts
+++ b/examples/src/summarize.ts
@@ -53,7 +53,7 @@ async function main() {
       console.log(`  - ${point}`);
     }
   } finally {
-    agent.close();
+    await agent.close();
   }
 }
 

--- a/examples/src/unminify.ts
+++ b/examples/src/unminify.ts
@@ -275,7 +275,7 @@ async function main() {
     console.log(`  Step 5 (Apply renames):     ${(step5EndTime - step4EndTime) / 1000}s`);
     console.log(`  Total time:                 ${(step5EndTime - startTime) / 1000}s`);
   } finally {
-    agent.close();
+    await agent.close();
   }
 }
 

--- a/packages/thinkwell/src/integration.test.ts
+++ b/packages/thinkwell/src/integration.test.ts
@@ -137,7 +137,7 @@ async function manualThinkwellTest() {
   } catch (error) {
     console.error("Error:", error);
   } finally {
-    agent.close();
+    await agent.close();
     console.log("\nConnection closed");
   }
 }
@@ -168,7 +168,7 @@ async function simpleManualTest() {
 
     console.log("Result:", result);
   } finally {
-    agent.close();
+    await agent.close();
   }
 }
 


### PR DESCRIPTION
Add workaround for `kiro-cli acp` (v1.25.0) which doesn't exit when stdin closes. The fix implements a graceful shutdown sequence with timeouts and signal escalation.

Changes:
- Wait 250ms for graceful exit after closing stdin
- Send SIGTERM if process hasn't exited
- Send SIGKILL after another 500ms if still running
- Suppress non-zero exit code logging during graceful shutdown
- Document workaround in doc/workarounds.md