### PR TITLE
docs: VSCode integration strategy RFDs

### DIFF
--- a/doc/rfd/remove-uri-scheme.md
+++ b/doc/rfd/remove-uri-scheme.md
@@ -1,0 +1,234 @@
+# RFD: Remove `thinkwell:*` URI Scheme
+
+## Summary
+
+Replace the custom `thinkwell:*` import URI scheme with standard npm package imports and redesign the agent connection API. The new `open()` function accepts a named agent string (like `'claude'` or `'codex'`) with built-in environment variable overrides, so the simplest scripts need only a single import and a single line to connect. This eliminates an entire category of IDE integration problems by making imports resolve natively through TypeScript, Node.js, and every editor and bundler — with zero configuration.
+
+## Background
+
+Thinkwell scripts currently use a custom URI scheme for imports:
+
+```typescript
+import { Agent } from "thinkwell:agent";
+import { CLAUDE_CODE } from "thinkwell:connectors";
+```
+
+The `thinkwell:*` scheme was inspired by Node.js built-in protocols like `node:fs`, providing a visually distinctive import convention. At runtime, the loader in `loader.ts` rewrites these to their corresponding npm package names before execution:
+
+| URI scheme | npm package |
+|---|---|
+| `thinkwell:agent` | `thinkwell` |
+| `thinkwell:connectors` | `thinkwell` |
+| `thinkwell:acp` | `@thinkwell/acp` |
+| `thinkwell:protocol` | `@thinkwell/protocol` |
+
+## Problem Statement
+
+The custom URI scheme creates friction across the entire toolchain:
+
+1. **VSCode / TypeScript:** `Cannot find module 'thinkwell:agent'` — TypeScript doesn't know how to resolve custom protocol imports. Users see red squiggles on every thinkwell import.
+
+2. **Other editors:** The same problem affects every IDE and editor with TypeScript support (WebStorm, Neovim, Helix, Zed, etc.).
+
+3. **`tsc` CLI:** Type-checking with `tsc` fails on these imports. There's no tsconfig option that resolves custom protocols without a plugin.
+
+4. **Bundlers:** Any bundler (esbuild, webpack, Vite) requires custom configuration to resolve `thinkwell:*` imports.
+
+5. **Plugin-based workarounds are fragile:** TypeScript Language Service plugins can suppress errors and monkey-patch module resolution, but:
+   - They don't affect `tsc` CLI builds
+   - The monkey-patching pattern (modifying `LanguageServiceHost`) is unofficial
+   - TypeScript 7 (the Go port, shipping March 2026) will not support the plugin API at all
+
+6. **`declare module` workarounds add maintenance burden:** Shipping ambient module declarations for `thinkwell:agent` etc. would work, but adds a layer of indirection that must be kept in sync.
+
+### The Key Observation
+
+The `thinkwell` package already has `package.json` `exports` for standard paths, and `Agent` is its primary export. The URI scheme is a parallel mechanism that the loader translates back to these same packages at runtime. The translation adds complexity without adding capability.
+
+## Proposal
+
+### The new API
+
+**Before:**
+```typescript
+import { Agent } from "thinkwell:agent";
+import { CLAUDE_CODE } from "thinkwell:connectors";
+
+const agent = await Agent.connect(process.env.THINKWELL_AGENT_CMD ?? CLAUDE_CODE);
+```
+
+**After:**
+```typescript
+import { open } from "thinkwell";
+
+const agent = await open('claude');
+```
+
+Three changes work together to simplify this:
+
+1. The `thinkwell:agent` specifier becomes the standard `"thinkwell"` import.
+2. The connectors module is replaced by named agent strings.
+3. The `Agent.connect()` static method is replaced by a top-level `open()` function, which handles agent resolution and environment variable overrides internally.
+
+For the scoped packages, no change is needed — users can import `@thinkwell/acp` and `@thinkwell/protocol` directly (and some likely already do).
+
+### `open()` API design
+
+```typescript
+type AgentName = 'claude' | 'codex' | 'gemini' | 'kiro' | 'opencode' | 'auggie';
+
+interface AgentOptions {
+  /** Custom command to spawn the agent process (mutually exclusive with AgentName) */
+  cmd?: string;
+  /** Environment variables for the agent process */
+  env?: Record<string, string>;
+  /** Connection timeout in milliseconds */
+  timeout?: number;
+}
+
+// Named agent (the common case)
+async function open(name: AgentName, options?: AgentOptions): Promise<Agent>;
+
+// Custom command
+async function open(options: AgentOptions & { cmd: string }): Promise<Agent>;
+```
+
+**Usage patterns:**
+
+```typescript
+// Named agent — the 90% case
+const agent = await open('claude');
+
+// Named agent with options
+const agent = await open('claude', { timeout: 30000 });
+
+// Custom command
+const agent = await open({ cmd: 'myagent --acp' });
+
+// Custom command with options
+const agent = await open({ cmd: 'myagent --acp', timeout: 30000, env: { DEBUG: '1' } });
+```
+
+When the first argument is an `AgentName`, specifying `cmd` in the options is disallowed (they're mutually exclusive — one selects a known agent, the other provides an arbitrary command).
+
+### Environment variable override
+
+`open()` checks two environment variables before resolving the agent:
+
+- `$THINKWELL_AGENT` — an agent name: `THINKWELL_AGENT=opencode thinkwell script.ts`
+- `$THINKWELL_AGENT_CMD` — a command string: `THINKWELL_AGENT_CMD="myagent --acp" thinkwell script.ts`
+
+If both are set, `$THINKWELL_AGENT_CMD` takes precedence (it's the more specific override). Either way, the env override applies regardless of what the script passes to `open()`. This is an ecosystem convention: scripts declare a *default* agent, but users can swap agents at runtime without changing code.
+
+### Agent name resolution
+
+Each `AgentName` maps to a command string:
+
+| Name | Command |
+|---|---|
+| `'claude'` | `npx -y @zed-industries/claude-code-acp` |
+| `'codex'` | `npx -y @zed-industries/codex-acp` |
+| `'gemini'` | `npx -y @google/gemini-cli --experimental-acp` |
+| `'kiro'` | `kiro-cli acp` |
+| `'opencode'` | `opencode acp` |
+| `'auggie'` | `auggie --acp` |
+
+This table lives in the `open()` implementation. The `connectors/index.ts` module is removed.
+
+**Note:** The current `connectors/index.ts` has an incorrect command string for Kiro (`kiro-cli chat acp` instead of `kiro-cli acp`). This should be fixed as part of the implementation.
+
+### Changes required
+
+**1. Add the `open()` function:**
+- Add the `AgentName` type and the agent name → command mapping
+- Implement the overloaded `open()` function with env override logic
+- Export it from the package root
+- Implement `AgentOptions` (rename from `ConnectOptions`, add `cmd`)
+- Actually use the `env` and `timeout` options (currently ignored in `connect()`)
+- Deprecate or remove `Agent.connect()`
+
+**2. Remove the connectors module:**
+- Delete `packages/thinkwell/src/connectors/index.ts`
+- Remove the `./connectors` subpath from `package.json` `exports`
+
+**3. User-facing code (examples and docs):**
+Update all import and connection statements:
+- `import { Agent } from "thinkwell:agent"` → `import { Agent } from "thinkwell"`
+- `import { CLAUDE_CODE } from "thinkwell:connectors"` → remove
+- `Agent.connect(CLAUDE_CODE)` → `open('claude')`
+- `"thinkwell:acp"` → `"@thinkwell/acp"`
+- `"thinkwell:protocol"` → `"@thinkwell/protocol"`
+
+**4. Loader (`packages/thinkwell/src/cli/loader.ts`):**
+- Remove the `THINKWELL_MODULES` mapping table
+- Remove the `rewriteThinkwellImports()` function
+- Update `needsTransformation()` to no longer check for `thinkwell:*` patterns
+- Remove references in the doc comments
+
+**5. Build system (`packages/thinkwell/src/cli/build.ts`):**
+- Remove any esbuild `onResolve` hooks for `thinkwell:*` specifiers
+
+**6. Init template (`packages/thinkwell/src/cli/init-command.ts`):**
+- Update the scaffolded example script to use `open()`
+
+**7. Tests:**
+- Update test fixtures and assertions that reference `thinkwell:*` imports
+- Remove tests specific to URI scheme rewriting
+- Add tests for `open()` overloads and env override behavior
+
+**8. Binary entry point (`packages/thinkwell/src/cli/main.cjs`):**
+- The `global.__bundled__` registry is keyed by npm package name, not URI — no change needed
+
+**9. Documentation and website:**
+- Update all code examples across the website
+
+### What stays the same
+
+- The `global.__bundled__` registry and bundled module resolution — this is keyed by npm package names and is unaffected
+- The `@JSONSchema` processing pipeline — completely independent of the import scheme
+- The `.js` → `.ts` extension rewriting — unrelated
+- The esbuild bundling for `thinkwell build` — standard npm imports are what esbuild already expects
+
+## Design Decisions
+
+### Why not keep both syntaxes with a deprecation period?
+
+Supporting both syntaxes means maintaining the rewriting infrastructure and testing both paths. The URI scheme has not been released to external users yet, so there's no backwards compatibility obligation. A clean break is simpler.
+
+### Why a top-level `open()` function instead of `Agent.connect()`?
+
+Two improvements over the previous API:
+
+- **`open` instead of `connect`:** "Open" frames the operation at the right level of abstraction. Opening an agent should feel as simple and commonplace as opening a file — you name what you want and start using it. "Connect" leaks the lower-level ACP transport model, which is an implementation detail users shouldn't need to think about.
+- **Top-level function instead of static method:** `open('claude')` is more concise and idiomatic than `Agent.open('claude')`. It also means users who only need to open an agent and call `.think()` don't need to import the `Agent` class at all — `import { open } from "thinkwell"` is the only import they need.
+
+### Why named agent strings instead of command constants?
+
+The previous API required users to import command strings like `CLAUDE_CODE` and understand that they were shell commands. Named strings like `'claude'` are:
+
+- **Simpler:** No second import, no need to know the underlying command
+- **Discoverable:** The `AgentName` type provides autocomplete for all supported agents
+- **Agent-neutral:** Thinkwell doesn't privilege any particular agent — they're all just names in a union type
+- **Readable:** `open('claude')` reads like plain English
+
+Users who need custom commands can pass `{ cmd: '...' }` directly.
+
+### Why built-in environment variable overrides?
+
+The `$THINKWELL_AGENT` and `$THINKWELL_AGENT_CMD` overrides are an ecosystem convention that decouples scripts from specific agents. A script says "use Claude by default" but an end user can run `THINKWELL_AGENT=opencode thinkwell script.ts` to swap agents without modifying code. This is especially valuable for:
+
+- Testing scripts across different agents
+- Teams with different agent preferences
+- CI environments where the agent may differ from development
+
+## Impact
+
+After this change, thinkwell **import statements** will resolve natively for projects that have `thinkwell` installed as an npm dependency. No plugins, no generated files, no tsconfig changes, no `declare module` declarations — standard `package.json` `exports` handle everything.
+
+### Remaining IDE gaps
+
+Two categories of errors remain after this change:
+
+1. **Standalone scripts without `node_modules`:** The `thinkwell` CLI supports standalone scripts (e.g., with a `#!/usr/bin/env thinkwell` shebang) that don't require a `package.json` or `npm install`. The CLI bundles all thinkwell dependencies internally, but VSCode has no `node_modules/thinkwell` to resolve against and will still report `Cannot find module 'thinkwell'`. The VSCode extension in [vscode-ts-plugin](vscode-ts-plugin.md) can solve this by resolving `thinkwell` imports to the CLI's bundled type declarations for detected thinkwell scripts.
+
+2. **`@JSONSchema` type augmentation:** Expressions like `Greeting.Schema` will still show errors because TypeScript doesn't know about the runtime-injected namespace members. Solving that is the subject of the [vscode-ts-plugin](vscode-ts-plugin.md) and [tsgo-api-migration](tsgo-api-migration.md) RFDs.

--- a/doc/rfd/tsgo-api-migration.md
+++ b/doc/rfd/tsgo-api-migration.md
@@ -1,0 +1,176 @@
+# RFD: Migrate VSCode Extension to `tsgo` IPC API
+
+## Summary
+
+Migrate the Thinkwell VSCode extension from the TypeScript Language Service Plugin API (which TypeScript 7 discontinues) to the new `tsgo` IPC-based API. The `tsgo` API provides a sanctioned mechanism for virtual file provision via `callbackfs`, enabling the same `@JSONSchema` augmentation without monkey-patching — and with a stable foundation for the TypeScript Go era.
+
+This RFD is forward-looking. The `tsgo` API is in early prototype as of February 2026. The timeline for this migration depends on API stabilization, but the architectural direction is clear and the necessary primitives are being built.
+
+## Background
+
+### The TypeScript 7 Transition
+
+TypeScript is being rewritten in Go (codename "Corsa"). TypeScript 7.0 ships mid-March 2026 alongside TypeScript 6.0 (the final JavaScript-based release):
+
+| Version | Language | Editor service | Plugin API |
+|---|---|---|---|
+| TypeScript 5.x/6.x | JavaScript | tsserver (custom protocol) | TS Language Service Plugin (JS-based) |
+| TypeScript 7.x | Go | `tsgo` (native LSP) | IPC-based API (new) |
+
+The existing TS plugin API is fundamentally incompatible with the Go binary — there is no way to load JavaScript plugin code into a compiled Go process. This affects every framework that extends TypeScript: Vue/Volar, Svelte, Angular, and Thinkwell.
+
+### The Coexistence Window
+
+TypeScript 6.x will be maintained indefinitely with no hard sunset date. Users can run both versions side-by-side: TypeScript 6.x for tooling that needs the old API, and `tsgo` for fast type-checking. This provides a long runway for migration, but the direction is clear — the Go port is the future.
+
+### Current State of the `tsgo` API
+
+Two merged PRs establish the foundation:
+
+**[PR #711](https://github.com/microsoft/typescript-go/pull/711): IPC API scaffold**
+- Synchronous Node.js client communicating with `tsgo` over STDIO
+- AST access, symbol resolution, type queries via opaque object handles
+- Two packages: `@typescript/ast` (node definitions) and `@typescript/api` (client)
+
+**[PR #2620](https://github.com/microsoft/typescript-go/pull/2620): Async API and LSP integration**
+- `custom/initializeAPISession` LSP command — a VSCode extension can request an API connection to the running `tsgo` language server
+- The API session shares the same type checker state as the editor's LSP session
+- `callbackfs` — a callback-based virtual filesystem over IPC, implementing `ReadFile`, `FileExists`, `DirectoryExists`, `GetAccessibleEntries`, and `Realpath`
+- Explicitly positioned as "the beginnings of a path toward replacing TS Server plugins"
+
+## The `callbackfs` Mechanism
+
+This is the key primitive for Thinkwell's migration. When `tsgo` needs to read a file, `callbackfs` intercepts the read and delegates to the IPC client:
+
+```
+tsgo language server                    Thinkwell extension
+        │                                       │
+        │  ReadFile("project/greeting.ts")      │
+        ├──────────────────────────────────────►│
+        │                                       │
+        │  Returns: original source             │
+        │◄──────────────────────────────────────┤
+        │                                       │
+        │  FileExists("__thinkwell__.d.ts")     │
+        ├──────────────────────────────────────►│
+        │                                       │
+        │  Returns: true                        │
+        │◄──────────────────────────────────────┤
+        │                                       │
+        │  ReadFile("__thinkwell__.d.ts")       │
+        ├──────────────────────────────────────►│
+        │                                       │
+        │  Returns: generated namespace decls   │
+        │◄──────────────────────────────────────┤
+```
+
+The extension controls what files `tsgo` sees. It can:
+
+1. **Provide virtual declaration files** that don't exist on disk — making `@JSONSchema` namespace merges visible to the type checker
+2. **Present transformed source files** if needed — though for Thinkwell's current needs, virtual declarations are sufficient
+3. **Make virtual files appear in directory listings** via `GetAccessibleEntries`, so `tsgo` includes them in the project
+
+This achieves the same result as the TS plugin's `getExternalFiles()` + `getScriptSnapshot()` monkey-patching, but through an officially supported, stable API designed for exactly this use case.
+
+## Proposed Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ VSCode                                                           │
+│ ┌──────────────────────────────┐  ┌───────────────────────────┐  │
+│ │ Thinkwell VSCode Extension   │  │ TypeScript (Native) Ext   │  │
+│ │                              │  │ (runs tsgo as LSP)        │  │
+│ │ 1. Calls custom/initialize-  │  │                           │  │
+│ │    APISession                │  └──────────┬────────────────┘  │
+│ │ 2. Registers callbackfs      │             │                   │
+│ │    handlers                  │   ┌─────────▼─────────────────┐ │
+│ │ 3. Provides virtual .d.ts    ├──►│ tsgo (native LSP server)  │ │
+│ │    content on ReadFile       │   │                           │ │
+│ │ 4. Scans for @JSONSchema     │   │ callbackfs delegates      │ │
+│ │    markers                   │   │ file reads to extension   │ │
+│ └──────────────────────────────┘   └───────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Extension lifecycle
+
+1. **Activation:** The extension activates when a workspace contains `thinkwell` as a dependency.
+
+2. **API session:** The extension calls the `custom/initializeAPISession` LSP command on the `tsgo` language server, receiving a connection (Unix domain socket or named pipe) to an API session that shares the live type checker state.
+
+3. **Filesystem callbacks:** The extension registers `callbackfs` handlers. For most files, it passes through to the real filesystem. For the virtual `__thinkwell_augmentations__.d.ts`, it returns dynamically generated namespace declarations.
+
+4. **Source scanning:** Same as the TS plugin approach — scan project files for `@JSONSchema` markers, generate corresponding namespace merge declarations.
+
+5. **State adoption:** When files change, the extension uses `AdoptLSPState` to pick up the latest type checker snapshot, re-scans affected files, and updates the virtual declarations.
+
+### Dual-version support
+
+During the coexistence period, the extension should support both TypeScript versions:
+
+- **TypeScript ≤6.x (tsserver):** Use the TS Language Service Plugin from [vscode-ts-plugin](vscode-ts-plugin.md)
+- **TypeScript 7+ (tsgo):** Use the `callbackfs` API described here
+
+The extension detects which TypeScript version is active and uses the appropriate mechanism. This is the same pattern that VSCode's own TypeScript extension will need to manage during the transition.
+
+## What's Not Yet Available
+
+The `tsgo` API is explicitly described as "early prototype quality." Key gaps as of February 2026:
+
+| Capability | Status | Impact on Thinkwell |
+|---|---|---|
+| `callbackfs` (virtual files) | Merged (PR #2620) | Core mechanism — available |
+| `custom/initializeAPISession` | Merged (PR #2620) | Entry point — available |
+| `AdoptLSPState` (state sync) | Merged (PR #2620) | Needed for reactivity — available |
+| Diagnostics query | Not yet | Low impact — we provide declarations, tsgo computes diagnostics |
+| Completions query | Not yet | Low impact — same reason |
+| Custom completions injection | Not yet | Not needed if virtual declarations work |
+| "Proper hooks" for framework integration | Acknowledged, not designed | May not be needed for our use case |
+
+The critical observation: **Thinkwell's approach of providing virtual declaration files does not require diagnostics or completions hooks.** We provide the type information; TypeScript's own language service computes the IDE features from it. The primitives we need — `callbackfs`, API session creation, and state adoption — are already merged.
+
+## Open Questions
+
+### API stability timeline
+
+The `tsgo` API is in active development with no stability guarantees. When should we start building against it? Options:
+
+- **Aggressive:** Start now, accept API churn, be an early adopter and provide feedback
+- **Conservative:** Wait for an official beta/stability signal, rely on the TS 6.x plugin in the meantime
+- **Middle ground:** Build a proof-of-concept now to validate the approach, defer production use until API stabilizes
+
+### Virtual file discovery
+
+How does `tsgo` discover that `__thinkwell_augmentations__.d.ts` should be part of the project? Options:
+
+- The `callbackfs` `GetAccessibleEntries` callback could include it in directory listings
+- There may be an API method to register additional files with the project (analogous to `getExternalFiles()`)
+- We may need to include it via a `/// <reference>` directive or tsconfig `include` pattern
+
+This depends on `tsgo` API details that may not be finalized yet.
+
+### IPC performance for file reads
+
+Every file read goes through IPC. For most files, the extension will just pass through to the real filesystem, adding latency. Is there a way to only intercept specific files? The `callbackfs` design may support selective interception (only intercepting reads for files that match a pattern), or it may require the extension to handle all reads.
+
+## Timeline Considerations
+
+| Milestone | Estimated timing |
+|---|---|
+| TypeScript 7.0 ships | Mid-March 2026 |
+| `tsgo` API stabilizes for virtual file use cases | Unknown — depends on framework adoption pressure |
+| Thinkwell proof-of-concept on `tsgo` API | After API reaches beta quality |
+| Thinkwell production migration | After API stability guarantee |
+| TS 6.x plugin deprecation | When `tsgo` API has proven stable for ≥1 release cycle |
+
+The TS 6.x plugin provides a working solution during the entire transition. There is no urgency to migrate before the `tsgo` API is ready.
+
+## References
+
+- [PR #711: Scaffold IPC-based API](https://github.com/microsoft/typescript-go/pull/711)
+- [PR #2620: Async API and LSP integration](https://github.com/microsoft/typescript-go/pull/2620)
+- [Discussion #455: What is the API story?](https://github.com/microsoft/typescript-go/discussions/455)
+- [Announcing TypeScript Native Previews](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/#api-progress)
+- [Progress on TypeScript 7 — December 2025](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/)
+- [vscode-ts-plugin](vscode-ts-plugin.md) — the TS 5.x/6.x approach this migrates from
+- [remove-uri-scheme](remove-uri-scheme.md) — prerequisite for both approaches

--- a/doc/rfd/vscode-ts-plugin.md
+++ b/doc/rfd/vscode-ts-plugin.md
@@ -1,0 +1,181 @@
+# RFD: VSCode Extension with TypeScript Plugin for `@JSONSchema`
+
+## Summary
+
+Build a VSCode extension that bundles a TypeScript Language Service plugin to provide IDE support for the `@JSONSchema` feature. The plugin presents virtual type augmentations to TypeScript so that `Greeting.Schema` and other injected namespace members are visible in the editor — without generating any files on disk.
+
+This targets TypeScript 5.x/6.x. A separate RFD ([tsgo-api-migration](tsgo-api-migration.md)) covers the migration path to TypeScript 7+.
+
+## Background
+
+Thinkwell's `@JSONSchema` JSDoc marker triggers a runtime transformation: when a script is loaded, the loader scans for marked interfaces, generates JSON schemas, and injects TypeScript namespace declarations that merge with the interface:
+
+```typescript
+/** @JSONSchema */
+export interface Greeting {
+  message: string;
+}
+
+// At runtime, the loader injects:
+namespace Greeting {
+  export const Schema: SchemaProvider<Greeting> = { ... };
+}
+
+// So user code can write:
+const greeting = await agent.think(Greeting.Schema);
+```
+
+This works perfectly at runtime. But in the editor, TypeScript sees only the interface declaration and reports: `Property 'Schema' does not exist on type 'typeof Greeting'`.
+
+### Prerequisite
+
+This RFD assumes the `thinkwell:*` URI scheme has been removed per [remove-uri-scheme](remove-uri-scheme.md). For projects with `thinkwell` installed as an npm dependency, import resolution is handled natively by TypeScript through standard `package.json` exports. Two IDE gaps remain: `@JSONSchema` augmentation and standalone script support (see below).
+
+## Problem Statement
+
+The `@JSONSchema` transformation is project-specific — it depends on which interfaces in the user's code are marked with `@JSONSchema`. This means static type declarations shipped in the npm package can't solve it. Something has to analyze the user's code and tell TypeScript about the generated namespace members.
+
+### Approaches considered and rejected
+
+**Generated `.d.ts` files (`thinkwell types` command):**
+- Pollutes the user's directory with generated files (or hides them in `node_modules` where they may be cleaned)
+- Requires running a command or a watch process
+- Files can go stale, leading to confusing mismatches between editor state and runtime
+- Adds complexity to the build pipeline (gitignore rules, CI steps, etc.)
+
+**tsconfig `paths` or ambient declarations:**
+- Can't solve this problem — the augmentations are project-specific and depend on user-defined types
+
+## Proposal
+
+### Architecture
+
+A VSCode extension (`thinkwell-vscode`) that bundles a TypeScript Language Service plugin (`thinkwell-ts-plugin`). The extension auto-injects the plugin into the TypeScript language service, requiring no manual `tsconfig.json` changes.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ VSCode                                                           │
+│ ┌──────────────────────────────┐  ┌───────────────────────────┐  │
+│ │ Thinkwell VSCode Extension   │  │ Built-in TypeScript Ext   │  │
+│ │ (activates on thinkwell      │  │ (runs tsserver)           │  │
+│ │  projects)                   │  │                           │  │
+│ └──────────────────────────────┘  └──────────┬────────────────┘  │
+│                                              │                   │
+│                                   ┌──────────▼─────────────────┐ │
+│                                   │ tsserver                   │ │
+│                                   │ ┌────────────────────────┐ │ │
+│                                   │ │ thinkwell-ts-plugin    │ │ │
+│                                   │ │ (loaded as TS plugin)  │ │ │
+│                                   │ └────────────────────────┘ │ │
+│                                   └────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### How the TS plugin works
+
+The plugin intercepts TypeScript's language service using the standard decorator pattern (`ts.server.PluginCreateInfo`). It does four things:
+
+#### 1. Virtual declaration injection via `getExternalFiles()`
+
+The plugin uses the `getExternalFiles()` API to register a virtual `.d.ts` file with the TypeScript project. This file contains namespace merge declarations for all `@JSONSchema`-marked types discovered in the project:
+
+```typescript
+// Virtual file: __thinkwell_augmentations__.d.ts (never written to disk)
+
+import { SchemaProvider } from "thinkwell";
+
+declare namespace Greeting {
+  export const Schema: SchemaProvider<Greeting>;
+}
+
+declare namespace Sentiment {
+  export const Schema: SchemaProvider<Sentiment>;
+}
+```
+
+The plugin provides the content of this virtual file by monkey-patching `LanguageServiceHost.getScriptSnapshot()` — when TypeScript asks for the content of `__thinkwell_augmentations__.d.ts`, the plugin returns the dynamically generated declarations.
+
+#### 2. Source scanning for `@JSONSchema` markers
+
+The plugin watches for file changes (via `getSemanticDiagnostics` interception or project update events) and scans TypeScript source files for the `@JSONSchema` JSDoc marker. When it finds marked types, it:
+
+1. Extracts the type name and its exported status
+2. Generates a corresponding namespace declaration with a `Schema` property
+3. Updates the virtual declaration file
+4. Triggers a project update so TypeScript re-checks with the new declarations
+
+This reuses the same pattern-matching logic that the runtime loader uses in `schema.ts` — identifying types marked with `/** @JSONSchema */` via AST traversal.
+
+#### 3. Module resolution for standalone scripts
+
+The `thinkwell` CLI supports standalone scripts (e.g., with a `#!/usr/bin/env thinkwell` shebang) that don't require a `package.json` or `npm install` — the CLI bundles all thinkwell dependencies internally. But without `node_modules/thinkwell`, VSCode reports `Cannot find module 'thinkwell'`.
+
+The plugin solves this by monkey-patching `resolveModuleNameLiterals` on the `LanguageServiceHost`. When it encounters an import of `thinkwell` (or `@thinkwell/acp`, `@thinkwell/protocol`) in a file that has no `node_modules` resolution, it resolves the import to the type declarations bundled with the `thinkwell` CLI installation. The plugin locates the CLI binary (via `which thinkwell` or a configured path) and points TypeScript at its shipped `.d.ts` files.
+
+This uses the same monkey-patching approach as the Svelte and `typescript-plugin-css-modules` plugins for custom module resolution.
+
+#### 4. Diagnostic filtering (defensive)
+
+As a safety net, the plugin filters `getSemanticDiagnostics` to suppress any residual "Property 'Schema' does not exist" errors (code 2339) that reference known `@JSONSchema`-marked types. In practice, the virtual declaration file should prevent these errors from occurring, but the filter provides defense in depth.
+
+### VSCode extension responsibilities
+
+The extension itself (separate from the TS plugin) handles:
+
+1. **Plugin injection:** Uses the `typescript.tsserver.pluginPaths` configuration to load the bundled TS plugin without requiring a `tsconfig.json` `plugins` entry.
+
+2. **Project detection:** Activates when the workspace has `thinkwell` as a dependency in `package.json`, or when files with a `#!/usr/bin/env thinkwell` shebang are detected.
+
+3. **Status bar indicator:** Shows "Thinkwell" in the status bar when the plugin is active, providing feedback that augmentations are being provided.
+
+### What the user experiences
+
+1. Install the VSCode extension (one-time)
+2. Open a thinkwell project
+3. `Greeting.Schema` just works — completions, type checking, hover info, go-to-definition
+4. No generated files, no commands to run, no tsconfig changes
+
+## Technical Risks
+
+### Monkey-patching `LanguageServiceHost`
+
+The TS plugin API officially only wraps `LanguageService`, not `LanguageServiceHost`. Intercepting `getScriptSnapshot()` requires monkey-patching the host object, which is an unofficial pattern. This is the same approach used by:
+
+- [typescript-plugin-css-modules](https://github.com/mrmckeb/typescript-plugin-css-modules)
+- [Svelte language tools](https://github.com/sveltejs/language-tools/blob/master/packages/typescript-plugin/src/module-loader.ts)
+- Volar's `@volar/typescript` (`decorateLanguageServiceHost.ts`)
+
+It works reliably in practice but is not guaranteed by TypeScript's API contract.
+
+### TypeScript version compatibility
+
+This approach targets TypeScript 5.x and 6.x. **TypeScript 7 (the Go port) will not support this plugin API.** The [tsgo-api-migration](tsgo-api-migration.md) RFD covers the migration strategy. The key mitigation: TypeScript 6.x will be maintained indefinitely with no hard sunset date, providing a long coexistence window.
+
+### Performance
+
+Scanning project files for `@JSONSchema` markers must be fast. The initial implementation should:
+
+- Only scan files that are part of the TypeScript project (not all workspace files)
+- Cache scan results and only re-scan files that change
+- Use the lightweight regex check (`/@JSONSchema/`) before doing full AST traversal
+
+## Scope and Non-Goals
+
+**In scope:**
+- TS plugin that provides virtual declarations for `@JSONSchema` types
+- Module resolution for standalone thinkwell scripts (no `node_modules`)
+- VSCode extension wrapper that auto-injects the plugin
+- Completions, type checking, and hover for `.Schema` members
+
+**Not in scope (for this phase):**
+- CodeLens, snippets, or other VSCode-specific features
+- Support for editors other than VSCode (the TS plugin would work in any editor that loads tsconfig plugins, but the auto-injection is VSCode-specific)
+- `thinkwell run` or `thinkwell build` integration in the extension
+- Watch mode or file generation
+
+## References
+
+- [Writing a Language Service Plugin (TypeScript Wiki)](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin)
+- [getExternalFiles API discussion](https://github.com/microsoft/TypeScript/issues/29706)
+- [remove-uri-scheme](remove-uri-scheme.md) — prerequisite RFD
+- [tsgo-api-migration](tsgo-api-migration.md) — follow-up RFD for TypeScript 7 migration


### PR DESCRIPTION
## Summary

Three RFDs covering a layered strategy for VSCode integration, motivated by the TypeScript 7 Go port (shipping March 2026) and the goal of zero-config IDE support.

### Horizon 1: [Remove `thinkwell:*` URI scheme](doc/rfd/remove-uri-scheme.md)
- Replace custom `thinkwell:*` imports with standard npm imports
- Redesign connection API: `open('claude')` replaces `Agent.connect(CLAUDE_CODE)`
- Named agent strings with `$THINKWELL_AGENT` / `$THINKWELL_AGENT_CMD` env overrides
- Eliminates all import resolution errors for npm-installed projects

### Horizon 2: [VSCode extension with TS plugin](doc/rfd/vscode-ts-plugin.md)
- TS Language Service plugin for `@JSONSchema` virtual declarations
- Module resolution for standalone scripts without `node_modules`
- Zero user config — extension auto-injects the plugin
- Targets TypeScript 5.x/6.x

### Horizon 3: [Migrate to `tsgo` IPC API](doc/rfd/tsgo-api-migration.md)
- Migrate from TS plugin API (dead in TS 7) to `tsgo` `callbackfs` + IPC API
- Same virtual file approach, officially supported mechanism
- Based on merged PRs [#711](https://github.com/microsoft/typescript-go/pull/711) and [#2620](https://github.com/microsoft/typescript-go/pull/2620)

## Test plan

- [ ] Review each RFD for technical accuracy and completeness
- [ ] Validate that the `open()` API design covers all current usage patterns
- [ ] Confirm agent name → command mappings are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)