### PR TITLE
docs: add check command RFD

### DIFF
--- a/doc/plan.md
+++ b/doc/plan.md
@@ -1,0 +1,22 @@
+# Plan: `thinkwell check` Command
+
+See [RFD](rfd/check-command.md) for design rationale.
+
+## Phase 1: Core Implementation
+
+- [ ] Custom CompilerHost with thinkwell language extension support
+  - [ ] `thinkwell:*` import specifier resolution
+  - [ ] `@JSONSchema` ambient namespace declaration injection
+- [ ] Workspace detection (pnpm-workspace.yaml, package.json workspaces)
+- [ ] Package name resolution (`--package` flag with full and short names)
+- [ ] Multi-package sequential checking with per-package status reporting
+- [ ] `check` command handler in `packages/thinkwell/src/cli/check.ts`
+- [ ] Command dispatch in `main.cjs`
+- [ ] Add `check` to help text
+- [ ] Bundle as `cli-check.cjs` in `scripts/bundle.ts`
+
+## Deferred
+
+- `@JSONSchema` deep validation (actually running `ts-json-schema-generator`)
+- Conductor protocol compliance checking
+- Parallel type checking across workspace packages

--- a/doc/rfd/check-command.md
+++ b/doc/rfd/check-command.md
@@ -1,0 +1,355 @@
+# RFD: `thinkwell check` Command
+
+**Depends on:** [remove-uri-scheme](remove-uri-scheme.md)
+
+## Summary
+
+This document proposes a new `thinkwell check` command that performs type checking on a thinkwell project without producing any output files. Inspired by `cargo check` in Rust, the goal is to give developers the fastest possible feedback loop for catching type errors during development.
+
+The command uses the TypeScript compiler API with a custom `CompilerHost` that serves `@JSONSchema`-transformed source from memory. This is the same CompilerHost shared with `thinkwell build` (see [node-ux](node-ux.md)), but invoked with `--noEmit` to skip producing output files.
+
+## Motivation
+
+### The Problem
+
+During development, the primary question a developer asks after editing code is: **"Did I break anything?"** The answer to this question is dominated by type errors — mismatched interfaces, missing properties, incorrect return types, etc.
+
+Today, the fastest way to answer this question in a thinkwell project is `pnpm build`, which runs `tsc` and produces JavaScript output in `dist/`. This works, but it does unnecessary work: the developer doesn't need the `.js`, `.d.ts`, and `.js.map` files just to know if their types are correct. On larger projects, skipping emit can be meaningfully faster.
+
+### Analogy: `cargo check`
+
+Rust's `cargo check` is one of the most-used developer commands in the ecosystem. It runs the compiler's analysis passes (parsing, name resolution, type checking, borrow checking) but skips code generation and linking. This makes it significantly faster than `cargo build` for the most common development task: "does my code typecheck?"
+
+TypeScript offers the same escape hatch via `tsc --noEmit`, which skips generating `.js`, `.d.ts`, and source map files.
+
+### Use Cases
+
+1. **Rapid iteration** — Check types after a quick edit without waiting for full emit. Especially valuable in larger projects where declaration and source map generation add overhead.
+
+2. **CI gating** — Run type checking as a fast, early CI step before slower build and test stages. A failing `thinkwell check` can fail the pipeline in seconds rather than minutes.
+
+3. **Editor-independent checking** — Not all editors have robust TypeScript language server integration. `thinkwell check` provides a reliable command-line alternative that uses the same configuration as the build.
+
+4. **Pre-commit hooks** — A fast type check is ideal for pre-commit hooks where developers don't want to wait for a full build.
+
+### Design Goals
+
+- **Minimal** — Do one thing well: run the type checker and report errors.
+- **Fast** — Skip all unnecessary work (emit, declaration generation, source maps).
+- **Familiar** — Follow conventions from `cargo check` and `tsc --noEmit`.
+- **Consistent** — Use the same `tsconfig.json` configuration as `thinkwell build`, so type checking results are never surprising.
+
+## Proposal
+
+### Basic Usage
+
+```bash
+# Check the current project (single-package project)
+thinkwell check
+
+# Check all packages in a workspace (from workspace root)
+thinkwell check
+
+# Check a specific package by name
+thinkwell check --package @thinkwell/acp
+thinkwell check -p acp                     # short name also works
+
+# Check multiple specific packages
+thinkwell check -p @thinkwell/acp -p @thinkwell/protocol
+```
+
+### Command-Line Interface
+
+```
+thinkwell check [options]
+
+Options:
+  -p, --package <name>   Check a specific workspace package by name
+                          (can be specified multiple times)
+  --pretty               Enable colorized output (default: true if TTY)
+  --no-pretty            Disable colorized output
+  -h, --help             Show help message
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No type errors |
+| 1 | Type errors found |
+| 2 | Configuration error (e.g., tsconfig.json not found) |
+
+### Package Name Resolution
+
+The `--package` flag accepts either a full package name or a short name:
+
+| `--package` value | Matches |
+|-------------------|---------|
+| `@thinkwell/acp` | Exact match on `"name"` in `package.json` |
+| `acp` | Matches `@thinkwell/acp` (or any package whose name ends with `/acp`) |
+| `thinkwell` | Matches the `thinkwell` package (exact match) |
+
+**Ambiguity:** If a short name matches multiple packages, `thinkwell check` exits with code 2 and lists the matches, asking the user to use the full name.
+
+### Example Output
+
+**Single package (success):**
+```
+$ thinkwell check
+  Checking thinkwell...
+  No type errors found.
+```
+
+**Workspace (all packages):**
+```
+$ thinkwell check
+  Checking @thinkwell/protocol... ok
+  Checking @thinkwell/acp... ok
+  Checking @thinkwell/conductor... ok
+  Checking thinkwell... ok
+
+  All 4 packages passed.
+```
+
+**Workspace (failure in one package):**
+```
+$ thinkwell check
+  Checking @thinkwell/protocol... ok
+  Checking @thinkwell/acp...
+
+  src/extensions.ts(42,5): error TS2345: Argument of type 'string' is not
+    assignable to parameter of type 'number'.
+
+  Checking @thinkwell/conductor... ok
+  Checking thinkwell...
+
+  src/index.ts(18,3): error TS2741: Property 'name' is missing in type
+    '{}' but required in type 'AgentConfig'.
+
+  2 of 4 packages had errors.
+```
+
+**Specific package:**
+```
+$ thinkwell check -p acp
+  Checking @thinkwell/acp...
+  No type errors found.
+```
+
+## Architecture
+
+### The `@JSONSchema` Challenge
+
+After the [removal of the `thinkwell:*` URI scheme](remove-uri-scheme.md), thinkwell user scripts use standard npm package imports (`"thinkwell"`, `"@thinkwell/acp"`) that TypeScript resolves natively. The one remaining language extension that standard `tsc` cannot process directly is:
+
+**`@JSONSchema` code generation** — The `@JSONSchema` JSDoc tag on a type like `interface Greeting { ... }` triggers code injection that generates a companion namespace with a `Schema` property. User code then references `Greeting.Schema` at runtime. Since this namespace doesn't exist in the source, `tsc --noEmit` produces: `Property 'Schema' does not exist on type 'Greeting'`.
+
+This extension is fundamental to the thinkwell developer experience — it appears in every example and most user projects. A `thinkwell check` that can't handle it would be useless for the primary audience.
+
+### Always Use the Programmatic Path
+
+One approach would be to try to detect whether a package uses `@JSONSchema` and only use the custom CompilerHost when needed. But this detection is inherently fragile — it would require scanning source files for `@JSONSchema` tags before type checking even begins, or guessing based on heuristics like `package.json` dependencies.
+
+Instead, `thinkwell check` always uses the programmatic TypeScript compiler API with the custom CompilerHost. The CompilerHost is a superset of standard behavior: for files that don't contain `@JSONSchema`, it behaves identically to the default host — the transformation is a no-op pass-through. For a standard TypeScript package without `@JSONSchema`, the result is the same as `tsc --noEmit` — just invoked via the API rather than the CLI.
+
+### `@JSONSchema` Transformation Strategy
+
+To type-check user scripts that use `@JSONSchema`, the CompilerHost intercepts `getSourceFile()` and injects namespace declarations in memory. For a type like:
+
+```typescript
+/** @JSONSchema */
+export interface Greeting {
+  message: string;
+}
+```
+
+The CompilerHost serves a transformed version that includes the companion namespace:
+
+```typescript
+import type * as $$__thinkwell__acp__$$ from "@thinkwell/acp";
+
+/** @JSONSchema */
+export interface Greeting {
+  message: string;
+}
+namespace Greeting {
+  export const Schema: $$__thinkwell__acp__$$.SchemaProvider<Greeting> = ...;
+}
+```
+
+This reuses the existing `transformJsonSchemas()` from `schema.ts` — the same transformation the CLI loader applies at runtime. The CompilerHost serves the transformed source from the original file path, so TypeScript sees valid code without any intermediate files on disk. See the [Node UX RFD](node-ux.md) for the full CompilerHost architecture.
+
+### Implementation Strategy
+
+`thinkwell check` uses the TypeScript compiler API programmatically with a custom `CompilerHost` that injects `@JSONSchema` namespace declarations via `getSourceFile()`. This single path works for all packages — those with `@JSONSchema` and those without.
+
+```
+thinkwell check [-p <package>...]
+        │
+        ▼
+  Detect workspace (npm or pnpm)
+        │
+        ├── Workspace root + no --package  ──► check all packages
+        ├── Workspace root + --package     ──► resolve named packages
+        └── Non-workspace (single project) ──► check cwd
+        │
+        ▼  (for each package)
+  Resolve tsconfig.json in package directory
+        │
+        ▼
+  Use TypeScript compiler API with custom CompilerHost
+    • Inject @JSONSchema namespace declarations where needed
+    • Run getPreEmitDiagnostics() with --noEmit
+        │
+        ▼
+  Stream diagnostics to terminal
+        │
+        ▼
+  Exit 0 if all packages pass, 1 if any had errors
+```
+
+### Workspace Detection
+
+`thinkwell check` detects workspaces by examining the current working directory:
+
+1. **pnpm workspaces** — Look for `pnpm-workspace.yaml` in cwd. Parse the `packages` array to get glob patterns (e.g., `["packages/*", "examples"]`). Expand globs to find package directories.
+
+2. **npm workspaces** — Look for `"workspaces"` key in `package.json` in cwd. Parse the array of glob patterns (e.g., `["packages/*"]`). Expand globs to find package directories.
+
+3. **Single project** — If neither is found, treat cwd as a single-package project.
+
+When a workspace is detected, each matched directory is scanned for a `package.json` to read the package `"name"` field, and for a `tsconfig.json` to confirm it's a TypeScript package. Directories without a `tsconfig.json` are silently skipped (they may be non-TypeScript packages).
+
+**Detection priority:** If both `pnpm-workspace.yaml` and `package.json` `"workspaces"` exist (unusual but possible), prefer the pnpm configuration since pnpm ignores the npm `"workspaces"` field and uses its own config.
+
+### Package Resolution
+
+When `--package <name>` is specified:
+
+1. Detect the workspace as described above.
+2. Build a map of package name to directory by reading `package.json` in each workspace member.
+3. Try exact match on the full package name (e.g., `@thinkwell/acp`).
+4. If no exact match, try matching the short name against the last segment of scoped package names (e.g., `acp` matches `@thinkwell/acp`).
+5. If the short name is ambiguous (matches multiple packages), exit with code 2 and list the matches.
+6. If no match is found, exit with code 2 and list available package names.
+
+If `--package` is used but no workspace is detected, exit with code 2:
+```
+Error: --package can only be used in a workspace.
+No pnpm-workspace.yaml or package.json "workspaces" found in current directory.
+```
+
+### tsconfig.json Resolution
+
+For each package being checked, `thinkwell check` looks for `tsconfig.json` in the package's directory. If no `tsconfig.json` is found in a package:
+
+- **When checking all packages** (no `--package` flag): silently skip the package. This is expected for non-TypeScript workspace members.
+- **When checking a specific package** (`--package` given): exit with code 2 and report that the package has no `tsconfig.json`.
+
+### TypeScript Dependency
+
+Since `thinkwell check` uses the TypeScript compiler API directly (not the `tsc` CLI), it depends on the `typescript` npm package being importable. TypeScript is already a runtime dependency of the `thinkwell` package (used for `@JSONSchema` processing via `ts-json-schema-generator`), so no additional installation is needed when thinkwell is installed via npm.
+
+For the compiled binary distribution, TypeScript is bundled into the binary alongside thinkwell's other dependencies, so the programmatic API is available without any extraction or download step.
+
+## Relationship to Existing Commands
+
+### `thinkwell build`
+
+`thinkwell build` (see [node-ux](node-ux.md)) uses the same custom CompilerHost as `thinkwell check`, but with emit enabled — it produces `.js`, `.d.ts`, and source map output in the project's `outDir`. Both commands share the same CompilerHost infrastructure; the only difference is whether `program.emit()` is called.
+
+`thinkwell check` is the fast-feedback counterpart to `thinkwell build`: it verifies type correctness without producing any artifacts.
+
+### `thinkwell bundle`
+
+`thinkwell bundle` compiles a user script into a standalone executable (esbuild + pkg). It does **not** run `tsc` and does **not** check types. Developers would typically run `thinkwell check` during development and `thinkwell bundle` when ready to produce a distributable binary.
+
+### `pnpm build` / `npm run build` (monorepo development)
+
+For monorepo development, `pnpm build` (or `npm run build`) typically runs `tsc` across all packages, producing JavaScript output. `thinkwell check` provides a faster alternative when you only need type correctness feedback: it detects the workspace configuration, finds all TypeScript packages, and type-checks each with the CompilerHost — no emitted files, no `dist/` directories to clean up.
+
+## Trade-offs
+
+### Advantages
+
+| Aspect | Benefit |
+|--------|---------|
+| Speed | Skipping emit is faster than full `tsc`, especially for projects with declaration generation |
+| Workspace awareness | Automatically detects npm/pnpm workspaces and checks all packages with a single command |
+| Unified path | Single CompilerHost implementation handles both standard packages and user scripts with `@JSONSchema` |
+| Consistency | Uses same tsconfig.json as build; no divergent configuration |
+| Familiarity | Follows `cargo check` pattern known to Rust developers |
+
+### Disadvantages
+
+| Aspect | Impact |
+|--------|--------|
+| Complexity | User scripts require a custom CompilerHost to handle `@JSONSchema` namespace injection; this is more than a simple `tsc` wrapper |
+| Redundancy | For library packages, users who already know `tsc --noEmit` may not see the value |
+
+### Why Not Just `tsc --noEmit`?
+
+A reasonable question. The value of `thinkwell check` over raw `tsc --noEmit` is:
+
+1. **`@JSONSchema` support** — `tsc --noEmit` fails on user scripts that use `@JSONSchema` code generation because the injected namespaces don't exist in the source. `thinkwell check` handles this transparently by injecting namespace declarations via the CompilerHost before type checking.
+2. **Workspace awareness** — A single `thinkwell check` from the workspace root checks all packages. `tsc --noEmit` only checks one `tsconfig.json` at a time, requiring manual iteration or a separate script.
+3. **Discoverability** — New thinkwell users see `check` in the help output alongside `build` and `run`, forming a coherent command vocabulary.
+4. **Correct defaults** — Automatically locates the right `tsconfig.json` and applies `--noEmit` without the user needing to remember flags.
+5. **Future extensibility** — As thinkwell grows, `check` can incorporate additional validation (e.g., `@JSONSchema` correctness, conductor protocol compliance) beyond what `tsc` alone provides.
+6. **Compiled binary support** — When running from a compiled thinkwell binary, there is no `tsc` on `PATH`. `thinkwell check` handles this transparently.
+
+## Alternatives Considered
+
+### Alternative 1: Add `--check` Flag to `thinkwell build`
+
+**Description:** Instead of a separate command, add a `--check` flag to `thinkwell build` that skips the build and only type-checks.
+
+**Pros:** No new command to learn; fewer top-level commands.
+**Cons:** Conflates two distinct operations; `build --check` is confusing because "build" implies producing output. `cargo` deliberately made `check` a separate command rather than `build --check` for this reason.
+
+### Alternative 2: Integrate Type Checking into `thinkwell run`
+
+**Description:** Automatically type-check before running scripts.
+
+**Pros:** Catches errors before runtime.
+**Cons:** Adds latency to every script invocation; users who want fast iteration can use their editor's language server. This should be opt-in at most, not the default.
+
+### Alternative 3: Do Nothing
+
+**Description:** Document `tsc --noEmit` in the thinkwell docs and let users run it directly.
+
+**Pros:** Zero implementation effort.
+**Cons:** Doesn't work for user scripts that use `@JSONSchema` — which is most thinkwell user code. Also misses workspace awareness, compiled-binary support, and discoverability.
+
+## Future Evolution
+
+### Deep `@JSONSchema` validation
+
+This RFD handles `@JSONSchema` at the type level: it injects ambient namespace declarations so that references like `Greeting.Schema` type-check correctly. But it doesn't validate that the annotated types are actually compatible with JSON Schema generation (e.g., no functions, no circular references that `ts-json-schema-generator` can't handle).
+
+In the future we could add deeper validation by actually running `ts-json-schema-generator` against annotated types and surfacing its errors as diagnostics. This could be exposed as `thinkwell check --schemas` or folded into the default behavior once it's fast enough.
+
+### Parallel workspace checking
+
+Sequential checking keeps output clear but leaves performance on the table for large workspaces. A future phase could check packages in parallel with output buffering — printing each package's results as a complete block once it finishes.
+
+### TypeScript project references and incremental checking
+
+TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) (`tsc --build --noEmit`) let the compiler understand the dependency graph across a monorepo. With project references, `tsc` can skip re-checking packages whose inputs haven't changed, and it builds packages in topological order automatically. This would reduce the need for `--package` as a manual scoping mechanism — users could just run `thinkwell check` and let incremental logic handle the rest.
+
+For now, the workspace-based approach with `--package` is simpler and doesn't require users to set up `composite: true` or `references` arrays in their tsconfig files. Project references could be explored as an optimization path if monorepo check times become a pain point.
+
+### Conductor protocol compliance
+
+As the conductor protocol matures, `thinkwell check` could validate that agent implementations conform to the protocol's type contracts beyond what TypeScript's structural type system catches (e.g., required capability registrations, message handler completeness).
+
+## References
+
+- [RFD: Remove `thinkwell:*` URI Scheme](./remove-uri-scheme.md)
+- [RFD: Node-Native Developer Experience](./node-ux.md)
+- [RFD: `thinkwell bundle` Command](./user-build-command.md)
+- [RFD: Migrate Binary Distribution from Bun to pkg](./pkg-migration.md)
+- [`cargo check` documentation](https://doc.rust-lang.org/cargo/commands/cargo-check.html)
+- [TypeScript `--noEmit` compiler option](https://www.typescriptlang.org/tsconfig#noEmit)
+- [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API)
+- [`@typescript/vfs`](https://www.npmjs.com/package/@typescript/vfs) — Official virtual filesystem for TypeScript CompilerHost

--- a/doc/rfd/node-ux.md
+++ b/doc/rfd/node-ux.md
@@ -6,6 +6,8 @@
 
 This document proposes a build-time tooling experience for TypeScript developers who want to use thinkwell within their existing Node.js workflows — using their own `node`, `tsc`, `tsx`, or other tooling — without installing thinkwell as a global CLI. The key design constraint is **one programming model**: users write the same code regardless of whether they run via the thinkwell CLI or standard Node tooling. The only difference is a small amount of `package.json` configuration.
 
+The build tool uses the TypeScript compiler API with a custom `CompilerHost` that intercepts file reads and serves transformed source from memory. When TypeScript requests a source file, the host reads the original from disk, applies `@JSONSchema` namespace injection in memory, and returns the result. No staging directory or intermediate files are needed.
+
 ## Problem Statement
 
 Today, thinkwell's primary UX is the CLI: `thinkwell myscript.ts` or `thinkwell build`. The CLI handles source transformations at load time — most importantly, `@JSONSchema` processing that injects namespace declarations like `Greeting.Schema` alongside user-defined interfaces.
@@ -31,7 +33,7 @@ This means the only way to achieve `Greeting.Schema` is to have the namespace de
 
 ### Prerequisite: Remove `thinkwell:*` URI Scheme
 
-**This RFD depends on [remove-uri-scheme](remove-uri-scheme.md) being implemented first.** The entire node-native workflow relies on imports using standard npm package specifiers (`"thinkwell"`, `"@thinkwell/acp"`) that `tsc` can resolve natively. If user code still contains `thinkwell:*` imports, the staged files would contain specifiers that `tsc` cannot resolve — the build would fail. Once the URI scheme is removed, the only remaining transformation that needs build-time support is `@JSONSchema` namespace injection.
+**This RFD depends on [remove-uri-scheme](remove-uri-scheme.md) being implemented first.** The entire node-native workflow relies on imports using standard npm package specifiers (`"thinkwell"`, `"@thinkwell/acp"`) that `tsc` can resolve natively. If user code still contains `thinkwell:*` imports, the CompilerHost would need to handle specifier rewriting in addition to `@JSONSchema` injection — adding complexity without adding value. Once the URI scheme is removed, the only remaining transformation that needs build-time support is `@JSONSchema` namespace injection.
 
 ## Design Goals
 
@@ -41,7 +43,7 @@ This means the only way to achieve `Greeting.Schema` is to have the namespace de
 
 3. **Composable with existing tooling** — The build step fits naturally into `package.json` scripts, pre-commit hooks, CI pipelines, and watch-mode workflows.
 
-4. **Source files are sacred** — The user's original `.ts` files are never modified. Transformations are applied to copies in a staging directory.
+4. **Source files are sacred** — The user's original `.ts` files are never modified. Transformations are applied in memory via a custom CompilerHost; no intermediate files are written to disk.
 
 5. **Good developer experience** — Source maps, IDE navigation, and debugging should work correctly, pointing back to the user's original files.
 
@@ -49,7 +51,7 @@ This means the only way to achieve `Greeting.Schema` is to have the namespace de
 
 ### The Core Idea
 
-A new build tool that copies the user's TypeScript source into a staging directory, applies `@JSONSchema` namespace injection, and then invokes `tsc` on the staged files. The user's original sources are never touched. TypeScript compiles the transformed files and produces `.js` and `.d.ts` output in the project's `outDir`.
+A new build tool that uses the TypeScript compiler API programmatically with a custom `CompilerHost`. When TypeScript's compiler requests a source file via `getSourceFile()`, the host reads the original file from disk, applies `@JSONSchema` namespace injection in memory, and returns the transformed source via `ts.createSourceFile()`. TypeScript compiles these virtual source files and produces `.js` and `.d.ts` output in the project's `outDir`. No intermediate files or staging directory are created — the user's original sources are never touched.
 
 This command reclaims the name `thinkwell build` — currently used for compiling standalone binaries — for the standard tsc-based build that node-native developers expect. The existing binary compilation functionality is renamed to `thinkwell bundle`. See [CLI Interface: `build` vs `bundle`](#cli-interface-build-vs-bundle) below for the full rationale.
 
@@ -79,34 +81,34 @@ const greeting = await agent
 │ thinkwell build                                                       │
 │                                                                       │
 │  1. Read tsconfig.json from user's project                            │
-│  2. Copy source files to .thinkwell/staged/                           │
-│  3. Transform staged copies:                                          │
-│     • @JSONSchema → inject namespace declarations                     │
-│  4. Generate tsconfig for staged files (inherits user's config)       │
-│  5. Run tsc on staged directory                                       │
-│  6. Output goes to user's configured outDir                           │
+│  2. Create ts.Program with custom CompilerHost                        │
+│  3. CompilerHost.getSourceFile() for each file:                       │
+│     • Read original source from disk                                  │
+│     • If @JSONSchema markers present, inject namespace declarations   │
+│     • Return transformed source via ts.createSourceFile()             │
+│  4. program.emit() writes output to user's configured outDir          │
 │                                                                       │
-│  src/                     .thinkwell/staged/src/          dist/       │
-│  ├── types.ts       ──►   ├── types.ts (+ namespace)  ──► ├── types.js│
-│  ├── main.ts        ──►   ├── main.ts (copied)        ──► ├── main.js │
-│  └── tsconfig.json        └── tsconfig.json (generated)   └── ...     │
-│  (never modified)         (ephemeral)                     (output)    │
+│  src/                     CompilerHost (in memory)          dist/     │
+│  ├── types.ts       ──►   types.ts + namespace       ──►   types.js  │
+│  ├── main.ts        ──►   main.ts (pass-through)     ──►   main.js   │
+│  └── tsconfig.json                                         ...       │
+│  (never modified)         (no files on disk)               (output)  │
 │                                                                       │
 └───────────────────────────────────────────────────────────────────────┘
 ```
 
-### Staged Transformation Details
+### Virtual Transformation Details
 
-For each `.ts` file copied to the staging directory, the build tool applies `@JSONSchema` namespace injection (reusing the existing `transformJsonSchemas()` from `schema.ts`):
+When TypeScript requests a source file via `getSourceFile()`, the CompilerHost reads the original from disk and applies `@JSONSchema` namespace injection in memory (reusing the existing `transformJsonSchemas()` from `schema.ts`):
 
 ```typescript
-// Original (src/types.ts):
+// Original on disk (src/types.ts):
 /** @JSONSchema */
 export interface Greeting {
   message: string;
 }
 
-// Staged (.thinkwell/staged/src/types.ts):
+// Served in memory by CompilerHost (at the same path, src/types.ts):
 import type * as $$__thinkwell__acp__$$ from "@thinkwell/acp";
 
 /** @JSONSchema */
@@ -126,11 +128,11 @@ namespace Greeting {
 }
 ```
 
-Files that don't contain `@JSONSchema` are copied unchanged.
+Files that don't contain `@JSONSchema` are passed through unchanged from the real filesystem.
 
 ### Source Maps
 
-The staged files are structurally identical to the originals, with injected code added after type declarations. TypeScript's source maps will point to the staged files, but because the user's code is at the same line numbers (the namespace injection is appended after each type declaration, not prepended), the mapping is straightforward. We can post-process source maps to rewrite paths from `.thinkwell/staged/src/...` back to `src/...`.
+Since the CompilerHost serves transformed source from the original file paths, TypeScript's source maps point directly to the user's original files. No source map path rewriting is needed. The namespace injections are appended after each type declaration (not prepended), so line numbers for user code in the source maps remain correct.
 
 ### Example Workflow
 
@@ -153,26 +155,18 @@ The staged files are structurally identical to the originals, with injected code
 npm install
 npm run dev          # watches source, rebuilds on changes
 # ... edit src/types.ts, add @JSONSchema types
-# ... staged files update automatically, tsc recompiles
+# ... CompilerHost picks up changes, tsc recompiles
 ```
 
-### Dev Mode: Running Without Compilation
+### Dev Mode: Running Without Full Build
 
-For quick iteration without a full `tsc` build — e.g., running a script directly with `tsx` or `node --experimental-transform-types` — we also support a lighter-weight mode:
+For quick iteration without a full `tsc` build, users can continue to use `tsx` or `node --experimental-transform-types` directly on their source files. The `@JSONSchema` runtime injection is handled by the thinkwell CLI's loader — the same loader used by `thinkwell src/main.ts`.
 
-```bash
-thinkwell build --staged-only    # transform to staging dir, don't run tsc
-tsx .thinkwell/staged/src/main.ts
-```
+The CompilerHost-based build is primarily for users who want:
+- Full type checking with `@JSONSchema` support (via `thinkwell check`)
+- Compiled `.js`/`.d.ts` output (via `thinkwell build`)
 
-Or more concisely, if we provide a wrapper:
-
-```bash
-thinkwell run --node-native src/main.ts
-# equivalent to: stage the file, then exec tsx on the staged version
-```
-
-However, the primary workflow for node-native users is the full `tsc` build, since they presumably care about type-checking and `.js`/`.d.ts` output.
+For users who just want to run scripts, the thinkwell CLI's runtime transformation (`thinkwell src/main.ts`) remains the fastest path. For fast type-checking feedback during development, `thinkwell check --watch` provides continuous type checking without producing output files.
 
 ### CLI Interface: `build` vs `bundle`
 
@@ -181,7 +175,7 @@ The existing `thinkwell build` command compiles to standalone binaries (esbuild 
 The `bundle` command supports two output modes:
 
 ```
-thinkwell build              # tsc-based build (stages + tsc, this RFD)
+thinkwell build              # tsc-based build (CompilerHost + tsc, this RFD)
 thinkwell bundle             # self-contained JS bundle (esbuild, single .js file)
 thinkwell bundle --binary    # self-contained binary executable (esbuild + pkg)
 ```
@@ -192,20 +186,7 @@ This naming is precise and idiomatic: "build" is what TypeScript developers type
 
 ### Configuration
 
-The build tool reads the user's existing `tsconfig.json` to understand their compiler options (`outDir`, `target`, `module`, `strict`, etc.). The generated tsconfig for the staging directory extends the user's config:
-
-```json
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "../../dist",
-    "declarationMap": true,
-    "sourceMap": true
-  },
-  "include": ["src/**/*"]
-}
-```
+The CompilerHost reads the user's existing `tsconfig.json` directly to understand their compiler options (`outDir`, `target`, `module`, `strict`, etc.). No intermediate or generated tsconfig is needed.
 
 Additional thinkwell-specific configuration can go in `package.json`:
 
@@ -213,8 +194,6 @@ Additional thinkwell-specific configuration can go in `package.json`:
 {
   "thinkwell": {
     "build": {
-      "src": "src",
-      "staged": ".thinkwell/staged",
       "include": ["src/**/*.ts"],
       "exclude": ["**/*.test.ts", "**/__fixtures__/**"]
     }
@@ -222,18 +201,7 @@ Additional thinkwell-specific configuration can go in `package.json`:
 }
 ```
 
-By default, all files under `src` are staged. The optional `include` and `exclude` fields accept glob patterns for controlling which files are copied to the staging directory. This is useful for skipping test files, fixtures, or other sources that don't need `@JSONSchema` processing or tsc compilation through thinkwell.
-
-Or in `tsconfig.json` as a convention (though tsc will ignore unknown keys):
-
-```json
-{
-  "compilerOptions": { ... },
-  "thinkwell": {
-    "src": "src"
-  }
-}
-```
+The optional `include` and `exclude` fields accept glob patterns for controlling which files receive `@JSONSchema` processing. This is useful for skipping test files, fixtures, or other sources that don't need transformation. Files not matched by `include` (or matched by `exclude`) are still compiled by TypeScript — they just aren't transformed by the CompilerHost.
 
 ### Watch Mode
 
@@ -243,11 +211,11 @@ thinkwell build --watch
 
 Watch mode:
 1. Watches the source directory for `.ts` file changes
-2. Re-stages only changed files (incremental)
-3. Runs `tsc --watch` on the staged directory
+2. On change, re-runs the CompilerHost-based compilation (the CompilerHost reads fresh source from disk)
+3. Uses TypeScript's incremental compilation (`--incremental`) for fast re-checks
 4. Debounces rapid changes
 
-This provides the same experience as `tsc --watch` but with thinkwell transformations applied.
+This provides the same experience as `tsc --watch` but with thinkwell `@JSONSchema` transformations applied in memory.
 
 ## How This Interacts with the CLI Workflow
 
@@ -257,66 +225,94 @@ The CLI workflow (`thinkwell src/main.ts`) continues to work exactly as it does 
 |---|---|---|
 | User code | `Greeting.Schema` | `Greeting.Schema` (identical) |
 | Imports | `"thinkwell"`, `"@thinkwell/acp"` | Same |
-| `@JSONSchema` | Runtime injection | Build-time injection |
-| Build step | None | `thinkwell build` (stages + tsc) |
-| Run command | `thinkwell src/main.ts` | `node dist/main.js` or `tsx src/main.ts` via staged |
-| Type checking | Via tsc (on staged files) or VS Code extension | Via `tsc` (on staged files) |
+| `@JSONSchema` | Runtime injection | Build-time injection via CompilerHost |
+| Build step | None | `thinkwell build` (CompilerHost + tsc emit) |
+| Run command | `thinkwell src/main.ts` | `node dist/main.js` |
+| Type checking | `thinkwell check` or VS Code extension | `thinkwell check` (same CompilerHost) |
 | IDE support | VS Code extension ([vscode-ts-plugin](vscode-ts-plugin.md)) | Same VS Code extension |
 
 ### IDE Support
 
-IDE support for `@JSONSchema` augmentations is covered by a separate effort: the Thinkwell VS Code extension with a TypeScript Language Service plugin ([vscode-ts-plugin](vscode-ts-plugin.md)). The extension presents virtual namespace augmentations to TypeScript so that `Greeting.Schema` is visible in the editor without generating files on disk or requiring the staging directory to be in sync.
+IDE support for `@JSONSchema` augmentations is covered by a separate effort: the Thinkwell VS Code extension with a TypeScript Language Service plugin ([vscode-ts-plugin](vscode-ts-plugin.md)). The extension presents virtual namespace augmentations to TypeScript so that `Greeting.Schema` is visible in the editor without generating files on disk.
 
-This works identically for both workflows — the VS Code extension doesn't care whether the user runs scripts via the thinkwell CLI or standard Node tooling. The migration path to TypeScript 7's `tsgo` is covered in [tsgo-api-migration](tsgo-api-migration.md).
+This works identically for both workflows — the VS Code extension doesn't care whether the user runs scripts via the thinkwell CLI or standard Node tooling. All three mechanisms — the VS Code extension, `thinkwell check`, and `thinkwell build` — use the same concept of virtual/in-memory `@JSONSchema` injection, just through different interfaces (TS Language Service plugin for the IDE, CompilerHost for CLI tools). The migration path to TypeScript 7's `tsgo` is covered in [tsgo-api-migration](tsgo-api-migration.md).
+
+### Shared Infrastructure with `thinkwell check`
+
+The [`thinkwell check`](check-command.md) command uses the same custom CompilerHost as `thinkwell build`, but with `--noEmit`. Both commands:
+
+- Create a `ts.Program` using the same custom CompilerHost
+- Apply `@JSONSchema` namespace injection via `getSourceFile()` interception
+- Read the user's `tsconfig.json` directly
+
+The only difference is what happens after type checking:
+
+| | `thinkwell check` | `thinkwell build` |
+|---|---|---|
+| Type checking | Yes | Yes |
+| Emit (.js, .d.ts, source maps) | No (`--noEmit`) | Yes (`program.emit()`) |
+| Primary use | Fast feedback during development | Produce compiled output |
+
+This shared CompilerHost is implemented once and used by both commands, ensuring consistent `@JSONSchema` handling and reducing maintenance burden.
 
 ## Architecture
 
 ### Reuse of Existing Infrastructure
 
-The build tool reuses the core `@JSONSchema` transformation functions from `schema.ts`:
+The CompilerHost reuses the core `@JSONSchema` transformation functions from `schema.ts` inside its `getSourceFile()` implementation:
 
-| Existing Function | Used By |
+| Component | Used By |
 |---|---|
-| `findMarkedTypes()` | Both CLI and build tool |
-| `generateSchemas()` | Both CLI and build tool |
-| `generateInsertions()` | Both CLI and build tool |
-| `applyInsertions()` | Both CLI and build tool |
-| `generateSchemaImport()` | Both CLI and build tool |
-| `transformJsonSchemas()` | Both CLI and build tool (top-level orchestrator) |
+| `findMarkedTypes()` | CLI loader, CompilerHost `getSourceFile()` |
+| `generateSchemas()` | CLI loader, CompilerHost `getSourceFile()` |
+| `generateInsertions()` | CLI loader, CompilerHost `getSourceFile()` |
+| `applyInsertions()` | CLI loader, CompilerHost `getSourceFile()` |
+| `generateSchemaImport()` | CLI loader, CompilerHost `getSourceFile()` |
+| `transformJsonSchemas()` | CLI loader, CompilerHost `getSourceFile()` (top-level orchestrator) |
+| Custom `CompilerHost` | `thinkwell build`, `thinkwell check` |
 
-The build tool adds orchestration logic around these: file copying, staging directory management, tsconfig generation, tsc invocation, watch mode, and source map fixup.
+The build tool adds orchestration logic around these: CompilerHost creation, `ts.Program` construction, `program.emit()` invocation, watch mode, and diagnostic formatting.
 
-### Staging Directory Layout
+### CompilerHost Architecture
 
+The custom CompilerHost follows a hybrid pattern inspired by [`@typescript/vfs`](https://www.npmjs.com/package/@typescript/vfs): transformed source takes priority for project files, with fallback to the real filesystem for everything else (`node_modules`, lib files, declaration files).
+
+```typescript
+// Simplified CompilerHost structure
+const defaultHost = ts.createCompilerHost(options);
+
+const host: ts.CompilerHost = {
+  ...defaultHost,
+
+  getSourceFile(fileName, languageVersion) {
+    const source = ts.sys.readFile(fileName);
+    if (source === undefined) return undefined;
+
+    // Apply @JSONSchema transformation in memory
+    const transformed = transformJsonSchemas(fileName, source);
+    return ts.createSourceFile(fileName, transformed, languageVersion);
+  },
+
+  // All other methods (fileExists, readFile, module resolution, etc.)
+  // delegate to the default host, which reads from the real filesystem.
+};
+
+const program = ts.createProgram({ rootNames, options, host });
+
+// For thinkwell check:
+const diagnostics = ts.getPreEmitDiagnostics(program);
+
+// For thinkwell build:
+program.emit();
 ```
-project/
-├── src/
-│   ├── types.ts          # user's source (never modified)
-│   ├── main.ts           # user's source
-│   └── utils/
-│       └── helpers.ts
-├── .thinkwell/
-│   └── staged/
-│       ├── src/
-│       │   ├── types.ts      # transformed copy
-│       │   ├── main.ts       # transformed copy
-│       │   └── utils/
-│       │       └── helpers.ts
-│       └── tsconfig.json     # generated, extends ../../tsconfig.json
-├── dist/                     # tsc output
-├── tsconfig.json             # user's tsconfig
-└── package.json
-```
 
-The `.thinkwell/` directory should be gitignored (the `thinkwell init` template already gitignores `.thinkwell/`-style directories).
+The `transformJsonSchemas()` function is a no-op for files without `@JSONSchema` markers, so the CompilerHost is a transparent pass-through for standard TypeScript files.
 
-### Incremental Staging
+### Incremental Compilation
 
-To avoid unnecessary work:
+TypeScript's built-in incremental compilation (`"incremental": true` in tsconfig) works naturally with the CompilerHost approach. TypeScript writes `.tsbuildinfo` files to track what has changed between compilations. Since the CompilerHost serves files from their original paths, TypeScript's incremental state aligns correctly with the real filesystem.
 
-1. **Hash check** — Before writing a staged file, compare the transformed content against the existing staged file. Only write if different.
-2. **Modification time** — Track source file mtimes to skip re-reading files that haven't changed.
-3. **tsc incremental** — The staged tsconfig enables `"incremental": true` so tsc's own incremental compilation kicks in.
+The CompilerHost itself does not need to cache transformations between runs — the `@JSONSchema` transformation is fast (regex check + AST traversal only for files that contain the marker). The dominant cost is TypeScript's own type checking, which incremental mode already optimizes.
 
 ## Trade-offs
 
@@ -328,20 +324,33 @@ To avoid unnecessary work:
 | Familiar tooling | Uses tsc under the hood; developers understand the output |
 | Reuses existing code | Same transformation functions as the CLI |
 | Full type checking | tsc runs on complete, valid TypeScript (with namespace merges) |
-| Source map support | Output maps back to original source files |
+| Source map support | Output maps directly to original source files — no path rewriting needed |
+| No intermediate files | No staging directory, no duplicated files, no generated tsconfig |
+| Shared with `check` | Same CompilerHost used by `thinkwell check` — one implementation to maintain |
 
 ### Disadvantages
 
 | Aspect | Impact |
 |---|---|
-| Staging directory | Adds a `.thinkwell/staged/` directory (gitignored, but still disk usage) |
 | Build step required | Must run `thinkwell build` before running compiled output |
-| Source map complexity | Need to rewrite source map paths from staged → original |
-| Duplicated files | Every source file is copied to the staging directory, even files with no transformations |
+| TypeScript API coupling | Depends on TypeScript's `CompilerHost` interface, which is stable in practice but not a formally guaranteed public contract |
+| tsgo migration | TypeScript 7 (Go port, shipping March 2026) replaces `CompilerHost` with `callbackfs` over IPC — requires migration (see [tsgo-api-migration](tsgo-api-migration.md)) |
+| Implementation complexity | A custom CompilerHost is more complex to implement and debug than copying files to a directory |
+| Debugging opacity | Transformed source only exists in memory; harder to inspect than staged files on disk (mitigation: a `--verbose` flag that logs transformed source) |
+
+### Why Not a Staging Directory?
+
+An earlier version of this design proposed copying source files to `.thinkwell/staged/`, applying `@JSONSchema` namespace injection to the copies, then running `tsc` on the staged files. This was replaced by the CompilerHost approach because:
+
+1. **Source map complexity** — Staged files live at different paths from the originals, requiring post-processing of source maps to rewrite paths back to the user's source. The CompilerHost serves files from their original paths, eliminating this entirely.
+2. **Disk I/O overhead** — Every source file must be copied to the staging directory, even files without `@JSONSchema`. The CompilerHost only transforms files that need it; everything else is a pass-through read from the real filesystem.
+3. **Generated tsconfig** — The staging approach requires generating a second `tsconfig.json` that extends the user's config from the staging directory, introducing a layer of indirection and potential for configuration drift.
+4. **Shared infrastructure** — The `thinkwell check` command already uses the CompilerHost approach (with `--noEmit`). Using the same CompilerHost for `build` means one implementation to maintain rather than two parallel transformation mechanisms.
+5. **Cleaner project structure** — No `.thinkwell/staged/` directory to gitignore, no duplicated files on disk.
 
 ### Why Not Companion Files?
 
-An earlier version of this design proposed generating companion `.schemas.ts` files with exports like `GreetingSchema`. This was rejected because it creates a programming model split: CLI users write `Greeting.Schema` while node-native users write `import { GreetingSchema }`. Having one way to write thinkwell code is more important than avoiding a staging directory.
+An earlier version of this design proposed generating companion `.schemas.ts` files with exports like `GreetingSchema`. This was rejected because it creates a programming model split: CLI users write `Greeting.Schema` while node-native users write `import { GreetingSchema }`. Having one way to write thinkwell code is more important than avoiding a build step.
 
 ### Why Not a Custom Node Loader?
 
@@ -350,7 +359,7 @@ Node.js supports custom ESM loaders via `--loader` or `register()`. We considere
 1. **Loader API instability** — Node's loader API has changed significantly across versions and remains experimental.
 2. **Tooling incompatibility** — Custom loaders interact poorly with tsx, vitest, jest, and bundlers.
 3. **Debugging friction** — Cryptic errors when loaders misbehave.
-4. **No type checking** — A loader can make code run, but tsc still wouldn't see the namespace merges. You'd need the staging approach anyway for type-checking.
+4. **No type checking** — A loader can make code run, but tsc still wouldn't see the namespace merges. You'd need the CompilerHost approach anyway for type-checking.
 
 ### Why Not ts-patch or Custom TypeScript Transformers?
 
@@ -362,12 +371,15 @@ ts-patch allows program-level transformers that can inject files into the compil
 
 ## References
 
+- [RFD: `thinkwell check` Command](./check-command.md)
 - [RFD: Remove `thinkwell:*` URI Scheme](./remove-uri-scheme.md)
 - [RFD: VSCode Extension with TypeScript Plugin](./vscode-ts-plugin.md)
 - [RFD: Migrate to `tsgo` IPC API](./tsgo-api-migration.md)
 - [RFD: Schema Provider Interface](./schema-providers.md)
 - [RFD: CLI Distribution](./cli-distribution.md)
 - [RFD: `thinkwell bundle` Command](./user-build-command.md)
+- [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API)
+- [`@typescript/vfs`](https://www.npmjs.com/package/@typescript/vfs) — Official virtual filesystem for TypeScript CompilerHost
 - [TypeScript Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
 - [ts-json-schema-generator](https://www.npmjs.com/package/ts-json-schema-generator)
 - [TypeScript #9611: Modules don't allow merging](https://github.com/Microsoft/TypeScript/issues/9611)

--- a/doc/rfd/tsgo-api-migration.md
+++ b/doc/rfd/tsgo-api-migration.md
@@ -1,10 +1,10 @@
-# RFD: Migrate VSCode Extension to `tsgo` IPC API
+# RFD: Migrate to `tsgo` IPC API
 
-**Depends on:** [vscode-ts-plugin](vscode-ts-plugin.md)
+**Depends on:** [vscode-ts-plugin](vscode-ts-plugin.md), [node-ux](node-ux.md), [check-command](check-command.md)
 
 ## Summary
 
-Migrate the Thinkwell VSCode extension from the TypeScript Language Service Plugin API (which TypeScript 7 discontinues) to the new `tsgo` IPC-based API. The `tsgo` API provides a sanctioned mechanism for virtual file provision via `callbackfs`, enabling the same `@JSONSchema` augmentation without monkey-patching — and with a stable foundation for the TypeScript Go era.
+Migrate all three Thinkwell consumers of the TypeScript compiler API — the **VSCode extension**, **`thinkwell check`**, and **`thinkwell build`** — from the TypeScript 5.x/6.x JavaScript API to the new `tsgo` IPC-based API. TypeScript 7 (the Go port) discontinues both the Language Service Plugin API used by the VSCode extension and the `CompilerHost` API used by the CLI commands. The `tsgo` API provides `callbackfs`, a callback-based virtual filesystem over IPC, which replaces both mechanisms with a single sanctioned approach.
 
 This RFD is forward-looking. The `tsgo` API is in early prototype as of February 2026. The timeline for this migration depends on API stabilization, but the architectural direction is clear and the necessary primitives are being built.
 
@@ -20,6 +20,8 @@ TypeScript is being rewritten in Go (codename "Corsa"). TypeScript 7.0 ships mid
 | TypeScript 7.x | Go | `tsgo` (native LSP) | IPC-based API (new) |
 
 The existing TS plugin API is fundamentally incompatible with the Go binary — there is no way to load JavaScript plugin code into a compiled Go process. This affects every framework that extends TypeScript: Vue/Volar, Svelte, Angular, and Thinkwell.
+
+Similarly, the `CompilerHost` interface used by `thinkwell check` and `thinkwell build` to serve `@JSONSchema`-transformed source from memory (see [node-ux](node-ux.md), [check-command](check-command.md)) is a TypeScript JavaScript API that does not exist in `tsgo`. The `callbackfs` mechanism replaces both the plugin API and `CompilerHost` with the same IPC-based virtual filesystem abstraction.
 
 ### The Coexistence Window
 
@@ -74,7 +76,21 @@ The extension controls what files `tsgo` sees. It can:
 
 This achieves the same result as the TS plugin's `getExternalFiles()` + `getScriptSnapshot()` monkey-patching, but through an officially supported, stable API designed for exactly this use case.
 
+## Three Consumers, One Migration
+
+Thinkwell has three consumers of TypeScript's programmatic APIs, each using a different interface today but all converging on `callbackfs` in TypeScript 7:
+
+| Consumer | Current API (TS 5.x/6.x) | `tsgo` replacement | Transport |
+|---|---|---|---|
+| VSCode extension | TS Language Service Plugin | `callbackfs` via LSP session | IPC to running `tsgo` language server |
+| `thinkwell check` | `CompilerHost.getSourceFile()` | `callbackfs` via `@typescript/api` | IPC to spawned `tsgo api` process |
+| `thinkwell build` | `CompilerHost.getSourceFile()` + `program.emit()` | `callbackfs` via `@typescript/api` | IPC to spawned `tsgo api` process |
+
+All three use the same underlying mechanism — intercepting file reads to serve `@JSONSchema`-transformed source — but through different transports. The IDE connects to a running `tsgo` language server; the CLI commands spawn a `tsgo api` child process.
+
 ## Proposed Architecture
+
+### VSCode Extension
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
@@ -94,7 +110,7 @@ This achieves the same result as the TS plugin's `getExternalFiles()` + `getScri
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-### Extension lifecycle
+#### Extension lifecycle
 
 1. **Activation:** The extension activates when a workspace contains `thinkwell` as a dependency.
 
@@ -106,7 +122,7 @@ This achieves the same result as the TS plugin's `getExternalFiles()` + `getScri
 
 5. **State adoption:** When files change, the extension uses `AdoptLSPState` to pick up the latest type checker snapshot, re-scans affected files, and updates the virtual declarations.
 
-### Dual-version support
+#### Dual-version support
 
 During the coexistence period, the extension should support both TypeScript versions:
 
@@ -115,21 +131,86 @@ During the coexistence period, the extension should support both TypeScript vers
 
 The extension detects which TypeScript version is active and uses the appropriate mechanism. This is the same pattern that VSCode's own TypeScript extension will need to manage during the transition.
 
+### CLI Commands (`thinkwell check` and `thinkwell build`)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ thinkwell check / thinkwell build                            │
+│                                                              │
+│  1. Spawn tsgo api as child process (via @typescript/api)    │
+│  2. Load project (tsconfig.json)                             │
+│  3. Register callbackfs handlers:                            │
+│     • ReadFile: apply @JSONSchema transformation in memory   │
+│     • FileExists / DirectoryExists: delegate to real FS      │
+│  4. Request diagnostics (check) or emit (build)              │
+│  5. Stream results to terminal                               │
+│                                                              │
+│  thinkwell CLI              tsgo api (child process)         │
+│       │                           │                          │
+│       │  register callbackfs      │                          │
+│       ├─────────────────────────►│                           │
+│       │                           │                          │
+│       │  ReadFile("src/types.ts") │                          │
+│       │◄─────────────────────────┤                           │
+│       │                           │                          │
+│       │  transformed source       │                          │
+│       ├─────────────────────────►│                           │
+│       │                           │                          │
+│       │  diagnostics / emit       │                          │
+│       │◄─────────────────────────┤                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### Migration from CompilerHost
+
+Today, `thinkwell check` and `thinkwell build` use TypeScript's `CompilerHost` interface to intercept `getSourceFile()` and serve `@JSONSchema`-transformed source in memory (see [node-ux](node-ux.md), [check-command](check-command.md)). The migration replaces this with `callbackfs`:
+
+| CompilerHost method | `callbackfs` equivalent |
+|---|---|
+| `getSourceFile(fileName)` → transform and return | `ReadFile(fileName)` → transform and return |
+| `fileExists(fileName)` | `FileExists(fileName)` |
+| `directoryExists(dirName)` | `DirectoryExists(dirName)` |
+| `readFile(fileName)` | `ReadFile(fileName)` |
+| `readDirectory(...)` | `GetAccessibleEntries(dirName)` |
+| `realpath(path)` | `Realpath(path)` |
+
+The surface area is nearly identical — both are filesystem virtualization interfaces. The key difference is transport: `CompilerHost` methods are in-process function calls; `callbackfs` methods are IPC messages. The `@JSONSchema` transformation logic (`transformJsonSchemas()` from `schema.ts`) is unchanged; only the plumbing around it changes.
+
+#### Check vs. build
+
+The two commands differ only in what they request after type checking:
+
+- **`thinkwell check`:** Request diagnostics only (equivalent to today's `getPreEmitDiagnostics()` with `--noEmit`)
+- **`thinkwell build`:** Request diagnostics and then emit (equivalent to today's `program.emit()`)
+
+The `tsgo` IPC API will need to support both operations. Diagnostics queries are listed as "not yet available" in the current API, but are expected — they're fundamental to any type-checking tool.
+
+#### Dual-version support for CLI
+
+During the coexistence period, the CLI commands should support both TypeScript versions:
+
+- **TypeScript ≤6.x:** Use the `CompilerHost` approach (current implementation)
+- **TypeScript 7+:** Use `@typescript/api` with `callbackfs`
+
+The CLI can detect which TypeScript version is available and choose the appropriate path. Since the `@JSONSchema` transformation logic is shared, only the compiler invocation layer needs to be swapped.
+
 ## What's Not Yet Available
 
 The `tsgo` API is explicitly described as "early prototype quality." Key gaps as of February 2026:
 
-| Capability | Status | Impact on Thinkwell |
-|---|---|---|
-| `callbackfs` (virtual files) | Merged (PR #2620) | Core mechanism — available |
-| `custom/initializeAPISession` | Merged (PR #2620) | Entry point — available |
-| `AdoptLSPState` (state sync) | Merged (PR #2620) | Needed for reactivity — available |
-| Diagnostics query | Not yet | Low impact — we provide declarations, tsgo computes diagnostics |
-| Completions query | Not yet | Low impact — same reason |
-| Custom completions injection | Not yet | Not needed if virtual declarations work |
-| "Proper hooks" for framework integration | Acknowledged, not designed | May not be needed for our use case |
+| Capability | Status | Impact on VSCode extension | Impact on CLI commands |
+|---|---|---|---|
+| `callbackfs` (virtual files) | Merged (PR #2620) | Core mechanism — available | Core mechanism — available |
+| `custom/initializeAPISession` | Merged (PR #2620) | Entry point — available | Not used (CLI spawns `tsgo api` directly) |
+| `AdoptLSPState` (state sync) | Merged (PR #2620) | Needed for reactivity — available | Not needed (no persistent session) |
+| Diagnostics query | Not yet | Low impact — tsgo computes diagnostics from declarations | **Blocking** — `thinkwell check` needs to retrieve diagnostics |
+| Emit / output generation | Not yet | Not needed | **Blocking** — `thinkwell build` needs to produce .js/.d.ts output |
+| Completions query | Not yet | Low impact — tsgo computes completions from declarations | Not needed |
+| "Proper hooks" for framework integration | Acknowledged, not designed | May not be needed | May not be needed |
 
-The critical observation: **Thinkwell's approach of providing virtual declaration files does not require diagnostics or completions hooks.** We provide the type information; TypeScript's own language service computes the IDE features from it. The primitives we need — `callbackfs`, API session creation, and state adoption — are already merged.
+For the **VSCode extension**, the critical observation still holds: Thinkwell's approach of providing virtual declaration files does not require diagnostics or completions hooks. We provide the type information; TypeScript's own language service computes the IDE features from it. The primitives we need — `callbackfs`, API session creation, and state adoption — are already merged.
+
+For the **CLI commands**, the situation is different. `thinkwell check` needs to retrieve diagnostics from the `tsgo` API, and `thinkwell build` needs to trigger emit. Both are listed as "not yet available." These are fundamental operations that the `tsgo` API will certainly support eventually — they're core to any programmatic use of a compiler — but they block the CLI migration until they ship.
 
 ## Open Questions
 
@@ -155,24 +236,43 @@ This depends on `tsgo` API details that may not be finalized yet.
 
 Every file read goes through IPC. For most files, the extension will just pass through to the real filesystem, adding latency. Is there a way to only intercept specific files? The `callbackfs` design may support selective interception (only intercepting reads for files that match a pattern), or it may require the extension to handle all reads.
 
+This is especially relevant for the CLI commands, where startup latency matters. Today, the CompilerHost approach has zero IPC overhead — `getSourceFile()` is an in-process function call. The `callbackfs` migration adds IPC round-trips for every file read. For a project with hundreds of source files, the cumulative latency could be noticeable. Benchmarking will be needed once the API is available.
+
+### CLI process lifecycle
+
+For the CLI commands, what is the expected lifecycle of a `tsgo api` process? Options:
+
+- **One-shot:** Spawn `tsgo api`, load the project, get diagnostics/emit, exit. Simple but incurs startup cost on every invocation.
+- **Persistent daemon:** Spawn `tsgo api` once and reuse across multiple `thinkwell check` invocations (similar to how `tsc --watch` keeps the compiler alive). Lower latency but more complex process management.
+
+The one-shot model is simpler and matches the current `thinkwell check` behavior. The persistent model would benefit `thinkwell check --watch` and repeated invocations during development.
+
 ## Timeline Considerations
 
 | Milestone | Estimated timing |
 |---|---|
 | TypeScript 7.0 ships | Mid-March 2026 |
 | `tsgo` API stabilizes for virtual file use cases | Unknown — depends on framework adoption pressure |
-| Thinkwell proof-of-concept on `tsgo` API | After API reaches beta quality |
+| Diagnostics and emit available in `tsgo` API | Unknown — blocks CLI migration |
+| Thinkwell VSCode extension proof-of-concept | After `callbackfs` API reaches beta quality |
+| Thinkwell CLI proof-of-concept | After diagnostics/emit are available in `tsgo` API |
 | Thinkwell production migration | After API stability guarantee |
-| TS 6.x plugin deprecation | When `tsgo` API has proven stable for ≥1 release cycle |
+| TS 6.x plugin / CompilerHost deprecation | When `tsgo` API has proven stable for ≥1 release cycle |
 
-The TS 6.x plugin provides a working solution during the entire transition. There is no urgency to migrate before the `tsgo` API is ready.
+The VSCode extension can be migrated first, since the primitives it needs (`callbackfs`, API sessions, state adoption) are already merged. The CLI commands must wait for diagnostics and emit support.
+
+The TS 6.x plugin and `CompilerHost` approach provide working solutions during the entire transition. There is no urgency to migrate before the `tsgo` API is ready.
 
 ## References
 
+- [RFD: Node-Native Developer Experience](node-ux.md) — `thinkwell build` CompilerHost architecture
+- [RFD: `thinkwell check` Command](check-command.md) — `thinkwell check` CompilerHost architecture
+- [RFD: VSCode Extension with TypeScript Plugin](vscode-ts-plugin.md) — the TS 5.x/6.x IDE approach this migrates from
+- [RFD: Remove `thinkwell:*` URI Scheme](remove-uri-scheme.md) — prerequisite for all approaches
 - [PR #711: Scaffold IPC-based API](https://github.com/microsoft/typescript-go/pull/711)
 - [PR #2620: Async API and LSP integration](https://github.com/microsoft/typescript-go/pull/2620)
 - [Discussion #455: What is the API story?](https://github.com/microsoft/typescript-go/discussions/455)
 - [Announcing TypeScript Native Previews](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/#api-progress)
 - [Progress on TypeScript 7 — December 2025](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/)
-- [vscode-ts-plugin](vscode-ts-plugin.md) — the TS 5.x/6.x approach this migrates from
-- [remove-uri-scheme](remove-uri-scheme.md) — prerequisite for both approaches
+- [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) — the TS 5.x/6.x `CompilerHost` API being replaced
+- [`@typescript/vfs`](https://www.npmjs.com/package/@typescript/vfs) — official virtual filesystem for CompilerHost


### PR DESCRIPTION
## Summary

- Add RFD for `thinkwell check`, a `cargo check`-style command that type-checks thinkwell projects using a custom CompilerHost with `@JSONSchema` namespace injection
- Update the node-ux RFD to use CompilerHost/virtual filesystem instead of a staging directory
- Broaden the tsgo-api-migration RFD to cover all three TypeScript API consumers (VSCode extension, `thinkwell check`, and `thinkwell build`)
- Add implementation plan checklist in `doc/plan.md`

## Test plan

- [ ] Review RFDs for accuracy and completeness
- [ ] Verify cross-references between RFDs are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)