### PR TITLE
Fix discriminated unions schemas

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,8 @@
     "summarize": "thinkwell src/summarize.ts",
     "sentiment": "thinkwell src/sentiment.ts",
     "greeting": "thinkwell src/greeting.ts",
-    "unminify": "thinkwell src/unminify.ts"
+    "unminify": "thinkwell src/unminify.ts",
+    "classify": "thinkwell src/classify.ts"
   },
   "dependencies": {
     "@types/lodash": "^4.17.23",

--- a/examples/src/classify.ts
+++ b/examples/src/classify.ts
@@ -1,0 +1,91 @@
+/**
+ * Example: Classification with Discriminated Union
+ *
+ * This example demonstrates using a discriminated union type with @JSONSchema.
+ * The LLM classifies a customer message and returns one of several structured
+ * action types, each with different fields. The calling code then uses a
+ * type-safe switch on the discriminant to handle each case.
+ *
+ * Run with: thinkwell src/classify.ts
+ */
+
+import { open } from "thinkwell";
+
+// --- Variant interfaces ---
+
+export interface Refund {
+  type: 'refund';
+  /** The order ID to refund */
+  orderId: string;
+  /** The reason for the refund */
+  reason: string;
+}
+
+export interface Escalate {
+  type: 'escalate';
+  /** The department to escalate to */
+  department: string;
+  /** Priority level */
+  priority: 'low' | 'medium' | 'high';
+  /** Brief summary for the agent */
+  summary: string;
+}
+
+export interface Respond {
+  type: 'respond';
+  /** The response message to send to the customer */
+  message: string;
+}
+
+/**
+ * The action to take for a customer support message.
+ * @JSONSchema
+ */
+export type Action = Refund | Escalate | Respond;
+
+const sampleMessages = [
+  "I ordered a blender two weeks ago (order #BL-9921) and it arrived broken. I want my money back.",
+  "How do I change my shipping address for future orders?",
+  "This is the THIRD time my delivery has been late. I've been a customer for 10 years and I'm about to cancel everything. I need someone in charge to call me back NOW.",
+];
+
+async function main() {
+  const agent = await open('claude');
+
+  try {
+    console.log("=== Customer Support Classifier ===\n");
+
+    for (const message of sampleMessages) {
+      console.log(`Customer: "${message}"\n`);
+
+      const action = await agent
+        .think(Action.Schema)
+        .text(`
+          Classify the following customer support message and decide the
+          best action to take. Choose one of: refund (if they want money back),
+          escalate (if they need a manager or specialist), or respond (if you
+          can answer directly).
+        `)
+        .quote(message, "customer message")
+        .run();
+
+      switch (action.type) {
+        case 'refund':
+          console.log(`  → REFUND order ${action.orderId}`);
+          console.log(`    Reason: ${action.reason}\n`);
+          break;
+        case 'escalate':
+          console.log(`  → ESCALATE to ${action.department} (${action.priority})`);
+          console.log(`    Summary: ${action.summary}\n`);
+          break;
+        case 'respond':
+          console.log(`  → RESPOND: ${action.message}\n`);
+          break;
+      }
+    }
+  } finally {
+    await agent.close();
+  }
+}
+
+main();

--- a/packages/thinkwell/test-fixtures/node-ux-project/src/main.ts
+++ b/packages/thinkwell/test-fixtures/node-ux-project/src/main.ts
@@ -1,8 +1,10 @@
-import { Greeting, Person } from "./types.js";
+import { Greeting, Person, Choice } from "./types.js";
 
 // Verify that @JSONSchema namespace merging makes .Schema available
 const greetingSchema = Greeting.Schema.toJsonSchema();
 const personSchema = Person.Schema.toJsonSchema();
+const choiceSchema = Choice.Schema.toJsonSchema();
 
 console.log("Greeting schema type:", greetingSchema.type);
 console.log("Person schema type:", personSchema.type);
+console.log("Choice schema has oneOf:", "oneOf" in choiceSchema || "anyOf" in choiceSchema);

--- a/packages/thinkwell/test-fixtures/node-ux-project/src/types.ts
+++ b/packages/thinkwell/test-fixtures/node-ux-project/src/types.ts
@@ -10,3 +10,20 @@ export interface Person {
   name: string;
   age: number;
 }
+
+export interface Done {
+  type: 'done';
+  result: string;
+}
+
+export interface Rename {
+  type: 'rename';
+  newName: string;
+}
+
+export interface GiveUp {
+  type: 'giveup';
+}
+
+/** @JSONSchema */
+export type Choice = Done | Rename | GiveUp;

--- a/packages/thinkwell/tsconfig.test.json
+++ b/packages/thinkwell/tsconfig.test.json
@@ -1,0 +1,9 @@
+//This is not extended by the test configs, this solely exists for IDEs like Webstorm.
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Fixes #41 

The schema generation for unions is working as expected. The issue is that the MCP tool schema requires a top-level object, whereas unions generate an `anyOf` at the root.

To address this, we wrap the generated schema in an object whenever the outermost level is not already an object.