### PR TITLE
fix: update Claude agent command to renamed package

### DIFF
--- a/packages/acp/src/integration.test.ts
+++ b/packages/acp/src/integration.test.ts
@@ -260,7 +260,7 @@ async function manualIntegrationTest() {
   console.log("Starting manual integration test...");
 
   // The agent command - defaults to Claude Code ACP
-  const agentCommand = process.env.AGENT_COMMAND?.split(" ") ?? ["npx", "-y", "@zed-industries/claude-code-acp"];
+  const agentCommand = process.env.AGENT_COMMAND?.split(" ") ?? ["npx", "-y", "@zed-industries/claude-agent-acp"];
 
   console.log("Using agent command:", agentCommand.join(" "));
 

--- a/packages/thinkwell/src/agent.ts
+++ b/packages/thinkwell/src/agent.ts
@@ -39,7 +39,7 @@ export type AgentName = 'claude' | 'codex' | 'gemini' | 'kiro' | 'opencode' | 'a
  * Maps agent names to their spawn commands.
  */
 const AGENT_COMMANDS: Record<AgentName, string> = {
-  claude: "npx -y @zed-industries/claude-code-acp",
+  claude: "npx -y @zed-industries/claude-agent-acp",
   codex: "npx -y @zed-industries/codex-acp",
   gemini: "npx -y @google/gemini-cli --experimental-acp",
   kiro: "kiro-cli acp",

--- a/packages/thinkwell/src/integration.test.ts
+++ b/packages/thinkwell/src/integration.test.ts
@@ -178,7 +178,7 @@ describe("Thought Stream live integration", { skip: SKIP_LIVE }, () => {
  * 3. Execute and get typed result
  *
  * Environment variables:
- * - AGENT_COMMAND: The agent command (default: "npx -y @zed-industries/claude-code-acp")
+ * - AGENT_COMMAND: The agent command (default: "npx -y @zed-industries/claude-agent-acp")
  */
 async function manualThinkwellTest() {
   console.log("Starting manual thinkwell integration test...\n");

--- a/website/api/agent.mdx
+++ b/website/api/agent.mdx
@@ -28,7 +28,7 @@ Supported agent names:
 
 | Name | Command |
 |------|---------|
-| `'claude'` | `npx -y @zed-industries/claude-code-acp` |
+| `'claude'` | `npx -y @zed-industries/claude-agent-acp` |
 | `'codex'` | `npx -y @zed-industries/codex-acp` |
 | `'gemini'` | `npx -y @google/gemini-cli --experimental-acp` |
 | `'kiro'` | `kiro-cli acp` |

--- a/website/get-started/cli.mdx
+++ b/website/get-started/cli.mdx
@@ -281,7 +281,7 @@ If both are set, `THINKWELL_AGENT_CMD` takes precedence.
 
 | Name | Command |
 |------|---------|
-| `claude` | `npx -y @zed-industries/claude-code-acp` |
+| `claude` | `npx -y @zed-industries/claude-agent-acp` |
 | `codex` | `npx -y @zed-industries/codex-acp` |
 | `gemini` | `npx -y @google/gemini-cli --experimental-acp` |
 | `kiro` | `kiro-cli acp` |


### PR DESCRIPTION
## Summary
- Migrates the default Claude agent command from the deprecated `@zed-industries/claude-code-acp` to `@zed-industries/claude-agent-acp`
- Updates source code, tests, and website docs (historical RFD docs left as-is)

Closes #51

## Test plan
- [x] `pnpm build` passes
- [x] Verify `npx -y @zed-industries/claude-agent-acp` resolves and launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)