### PR TITLE
fix: validate agent result schema and improve error reporting (#72)

### DIFF
--- a/examples/src/greeting.ts
+++ b/examples/src/greeting.ts
@@ -70,8 +70,8 @@ async function main() {
     console.log(styleText(["bold", "white"], `✨ ${greeting.message}`));
   } catch (error) {
     status.clear();
-    console.error("Error:", error);
-    throw error;
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   } finally {
     await agent.close();
   }

--- a/examples/src/greeting.ts
+++ b/examples/src/greeting.ts
@@ -71,7 +71,7 @@ async function main() {
   } catch (error) {
     status.clear();
     console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await agent.close();
   }

--- a/features.json
+++ b/features.json
@@ -1,5 +1,6 @@
 {
   "features": {
+    "FAULT_INJECTION": false,
     "LOG_PERMISSIONS": false,
     "STRIP_CLAUDECODE_ENV": true
   }

--- a/packages/thinkwell/src/agent.ts
+++ b/packages/thinkwell/src/agent.ts
@@ -30,7 +30,7 @@ import type {
   ToolCallContent as AcpToolCallContent,
   ContentBlock as AcpContentBlock,
 } from "@agentclientprotocol/sdk";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -277,14 +277,57 @@ class AgentImpl implements Agent {
 }
 
 /**
+ * Protocol-level message tracer.
+ *
+ * When $THINKWELL_TRACE is set to a directory path, every JSON-RPC
+ * message flowing between the client and agent is appended to an
+ * NDJSON file in that directory (one file per open() call). Each
+ * line contains a monotonic sequence number, high-resolution
+ * timestamp, direction, and the full message payload.
+ *
+ * Usage:
+ *   THINKWELL_TRACE=/tmp/tw-trace thinkwell src/greeting.ts
+ *
+ * Then inspect the trace:
+ *   cat /tmp/tw-trace/trace-*.ndjson | jq .
+ */
+function createTracer(): ((dir: "recv" | "send", msg: unknown) => void) | null {
+  const traceDir = process.env.THINKWELL_TRACE;
+  if (!traceDir) return null;
+
+  mkdirSync(traceDir, { recursive: true });
+  const tracePath = join(traceDir, `trace-${Date.now()}.ndjson`);
+  let seq = 0;
+  const t0 = performance.now();
+
+  return (dir: "recv" | "send", msg: unknown) => {
+    const record = {
+      seq: seq++,
+      ms: Math.round((performance.now() - t0) * 1000) / 1000,
+      dir,
+      msg,
+    };
+    try {
+      appendFileSync(tracePath, JSON.stringify(record) + "\n");
+    } catch {
+      // Best-effort — don't crash on trace failures
+    }
+  };
+}
+
+/**
  * Convert a ComponentConnection to the SDK's Stream interface.
  */
-function componentConnectionToStream(connection: ComponentConnection): Stream {
+function componentConnectionToStream(
+  connection: ComponentConnection,
+  trace: ((dir: "recv" | "send", msg: unknown) => void) | null,
+): Stream {
   // Create a ReadableStream from the async iterable
   const readable = new ReadableStream<AnyMessage>({
     async start(controller) {
       try {
         for await (const message of connection.messages) {
+          trace?.("recv", message);
           controller.enqueue(message as AnyMessage);
         }
         controller.close();
@@ -297,6 +340,7 @@ function componentConnectionToStream(connection: ComponentConnection): Stream {
   // Create a WritableStream that sends to the connection
   const writable = new WritableStream<AnyMessage>({
     write(message) {
+      trace?.("send", message);
       connection.send(message as JsonRpcMessage);
     },
     close() {
@@ -569,7 +613,8 @@ export async function open(
   const pair = createChannelPair();
 
   // Create a Stream adapter from the ComponentConnection
-  const stream = componentConnectionToStream(pair.left);
+  const trace = createTracer();
+  const stream = componentConnectionToStream(pair.left, trace);
 
   // Create the MCP handler
   const mcpHandler = new McpOverAcpHandler();

--- a/packages/thinkwell/src/agent.ts
+++ b/packages/thinkwell/src/agent.ts
@@ -295,8 +295,13 @@ function createTracer(): ((dir: "recv" | "send", msg: unknown) => void) | null {
   const traceDir = process.env.THINKWELL_TRACE;
   if (!traceDir) return null;
 
-  mkdirSync(traceDir, { recursive: true });
-  const tracePath = join(traceDir, `trace-${Date.now()}.ndjson`);
+  try {
+    mkdirSync(traceDir, { recursive: true });
+  } catch {
+    // Best-effort — disable tracing if directory creation fails
+    return null;
+  }
+  const tracePath = join(traceDir, `trace-${process.pid}-${Date.now()}.ndjson`);
   let seq = 0;
   const t0 = performance.now();
 

--- a/packages/thinkwell/src/think-builder.ts
+++ b/packages/thinkwell/src/think-builder.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { features } from "./generated/features.js";
 import {
   mcpServer,
   createSkillServer,
@@ -550,15 +551,9 @@ class PlanImpl<Output> implements Plan<Output> {
     // Track if we've received a result
     let resultReceived = false;
     let result: Output | undefined;
+    let resultError: Error | undefined;
     let resolveResultReady: () => void;
     const resultReady = new Promise<void>((r) => { resolveResultReady = r; });
-
-    // Accept a return_result invocation, unwrapping if needed.
-    const acceptResult = (input: unknown) => {
-      result = (needsWrap ? (input as Record<string, unknown>).result : input) as Output;
-      resultReceived = true;
-      resolveResultReady();
-    };
 
     // Get the output schema for the return_result tool.
     // The Anthropic API requires tool input schemas to have type: "object" at
@@ -569,6 +564,46 @@ class PlanImpl<Output> implements Plan<Output> {
     const outputSchema = needsWrap
       ? { type: "object", properties: { result: rawSchema }, required: ["result"] }
       : rawSchema;
+
+    // Accept a return_result invocation, unwrapping if needed.
+    // Guard against double calls: the MCP handler and the multi-turn loop
+    // can both invoke acceptResult for the same tool call. The first call
+    // wins; subsequent calls are no-ops.
+    const acceptResult = (input: unknown) => {
+      if (resultReceived) return;
+      const value = (needsWrap ? (input as Record<string, unknown>).result : input) as Output;
+
+      // Validate required fields. Without a full JSON Schema validator,
+      // we check the most common failure mode: the agent omitting
+      // required properties from the result object.
+      const schemaRequired = (rawSchema as Record<string, unknown>).required;
+      let required = Array.isArray(schemaRequired) ? schemaRequired : undefined;
+
+      // Fault injection: THINKWELL_INJECT_REQUIRED_FIELD=fieldName adds
+      // a fake required field the agent can't satisfy, to test error UX.
+      if (features.FAULT_INJECTION) {
+        const injectedField = process.env.THINKWELL_INJECT_REQUIRED_FIELD;
+        if (injectedField) {
+          required = required ? [...required, injectedField] : [injectedField];
+        }
+      }
+      if (Array.isArray(required) && value != null && typeof value === "object") {
+        const obj = value as Record<string, unknown>;
+        const missing = required.filter((key: string) => !(key in obj));
+        if (missing.length > 0) {
+          resultError = new TypeError(
+            `Agent result is missing required field(s): ${missing.join(", ")}`
+          );
+          resultReceived = true;
+          resolveResultReady();
+          return;
+        }
+      }
+
+      result = value;
+      resultReceived = true;
+      resolveResultReady();
+    };
 
     // Add return instruction
     prompt += "\n\nWhen you have your answer, call the `return_result` MCP tool with the result.";
@@ -686,14 +721,8 @@ class PlanImpl<Output> implements Plan<Output> {
 
           await promptPromise;
 
-          // The ACP SDK's receive loop does not await #processMessage, so
-          // the prompt response can resolve before an in-flight return_result
-          // handler finishes its async chain. However, the session_update
-          // notification (tool_start) is processed synchronously — pushUpdate
-          // runs before any microtask yield — so it is guaranteed to be in
-          // our update queue before the prompt response resolves. If we saw
-          // the tool_start for return_result, the handler is in-flight and
-          // resultReady will resolve; otherwise the agent never called it.
+          // If we saw a tool_start for return_result but the MCP handler
+          // hasn't resolved yet, wait for it.
           if (!resultReceived && pendingToolCalls.some(c => c.name === "return_result")) {
             await resultReady;
           }
@@ -734,10 +763,14 @@ class PlanImpl<Output> implements Plan<Output> {
           await sendTurn(followUp);
         }
 
-        if (resultReceived && result !== undefined) {
+        if (resultError) {
+          stream.rejectResult(resultError);
+        } else if (resultReceived && result !== undefined) {
           stream.resolveResult(result);
+        } else if (resultReceived) {
+          stream.rejectResult(new TypeError("Agent returned an undefined value"));
         } else {
-          stream.rejectResult(new Error("Session ended without calling return_result"));
+          stream.rejectResult(new Error("Agent session ended without returning a result"));
         }
       } finally {
         stream.close();

--- a/packages/thinkwell/src/think-builder.ts
+++ b/packages/thinkwell/src/think-builder.ts
@@ -587,9 +587,17 @@ class PlanImpl<Output> implements Plan<Output> {
           required = required ? [...required, injectedField] : [injectedField];
         }
       }
-      if (Array.isArray(required) && value != null && typeof value === "object") {
+      if (Array.isArray(required)) {
+        if (value == null || typeof value !== "object") {
+          resultError = new TypeError(
+            `Agent result must be an object when schema has required fields, got ${value === null ? "null" : typeof value}`
+          );
+          resultReceived = true;
+          resolveResultReady();
+          return;
+        }
         const obj = value as Record<string, unknown>;
-        const missing = required.filter((key: string) => !(key in obj));
+        const missing = required.filter((key: string) => !Object.hasOwn(obj, key));
         if (missing.length > 0) {
           resultError = new TypeError(
             `Agent result is missing required field(s): ${missing.join(", ")}`

--- a/packages/thinkwell/src/tool-race.test.ts
+++ b/packages/thinkwell/src/tool-race.test.ts
@@ -5,21 +5,28 @@ import { createPlan } from "./think-builder.js";
 import type { AgentConnection, SessionHandler } from "./agent.js";
 
 /**
- * Regression test for the return_result race condition.
+ * Tests for return_result handling edge cases.
  *
- * The ACP SDK's ClientSideConnection#receive loop dispatches messages
- * without awaiting #processMessage. When an agent sends _mcp/message
- * (for return_result) followed immediately by the prompt response,
- * the prompt response can resolve before the return_result handler
- * finishes its async chain — causing "Session ended without calling
- * return_result".
- *
- * We reproduce this by mocking AgentConnection.prompt() to fire the
- * return_result tool call with a microtask delay (simulating the real
- * async handler chain) while resolving the prompt response immediately.
+ * These tests use a mock AgentConnection to exercise the result
+ * resolution logic in PlanImpl._executeStream without needing a
+ * real agent process.
  */
 
-function createMockConnection(opts: { delayTicks: number }): {
+const schema = {
+  toJsonSchema: () => ({
+    type: "object",
+    properties: { message: { type: "string" } },
+    required: ["message"],
+  }),
+};
+
+/**
+ * Create a mock AgentConnection where the prompt handler calls
+ * return_result via the MCP server and then returns the prompt
+ * response — matching real agent behavior where the agent waits
+ * for the MCP round-trip before completing the prompt.
+ */
+function createMockConnection(): {
   conn: AgentConnection;
   cleanup: () => void;
 } {
@@ -44,17 +51,14 @@ function createMockConnection(opts: { delayTicks: number }): {
       newSession: async () => ({ sessionId: "test-session" }),
       prompt: async () => {
         if (capturedServer) {
-          // Fire-and-forget: simulate the ACP SDK dispatching the
-          // _mcp/message without awaiting #processMessage.
-          (async () => {
-            for (let i = 0; i < opts.delayTicks; i++) await Promise.resolve();
-            await capturedServer.handleMethod("tools/call", {
-              name: "return_result",
-              arguments: { message: "Hello!" },
-            }, { connectionId: "c1", sessionId: "test-session" });
-          })();
+          // Real agents wait for the MCP round-trip before completing
+          // the prompt — _mcp/message is a JSON-RPC request, so the
+          // agent blocks until it gets the response.
+          await capturedServer.handleMethod("tools/call", {
+            name: "return_result",
+            arguments: { message: "Hello!" },
+          }, { connectionId: "c1", sessionId: "test-session" });
         }
-        // Prompt response resolves immediately (before tool handler completes)
         return { stopReason: "end_turn" };
       },
     } as any,
@@ -74,19 +78,9 @@ function createMockConnection(opts: { delayTicks: number }): {
   };
 }
 
-const schema = {
-  toJsonSchema: () => ({
-    type: "object",
-    properties: { message: { type: "string" } },
-    required: ["message"],
-  }),
-};
-
-describe("return_result race condition", () => {
-  it("should resolve result when return_result handler is delayed by many microtask hops", async () => {
-    // 20 microtask hops simulates the real async chain depth in the
-    // ACP SDK (extMethod → routeRequest → handleMessage → handleToolsCall).
-    const { conn, cleanup } = createMockConnection({ delayTicks: 20 });
+describe("return_result handling", () => {
+  it("should resolve result via MCP round-trip", async () => {
+    const { conn, cleanup } = createMockConnection();
 
     try {
       const result = await createPlan(conn, schema)
@@ -99,17 +93,146 @@ describe("return_result race condition", () => {
     }
   });
 
-  it("should resolve result with no delay (synchronous path)", async () => {
-    const { conn, cleanup } = createMockConnection({ delayTicks: 0 });
+  it("should reject when agent never calls return_result", async () => {
+    const mcpHandler = new McpOverAcpHandler();
+    const sessionHandlers = new Map<string, SessionHandler>();
+
+    const conn: AgentConnection = {
+      conductor: { shutdown: async () => {} } as any,
+      connection: {
+        initialize: async () => ({
+          protocolVersion: 1,
+          serverInfo: { name: "mock" },
+          capabilities: {},
+        }),
+        newSession: async () => ({ sessionId: "test-session" }),
+        prompt: async () => {
+          return { stopReason: "end_turn" };
+        },
+      } as any,
+      mcpHandler,
+      sessionHandlers,
+      initialized: false,
+      conductorPromise: Promise.resolve(),
+    };
+
+    mcpHandler.waitForToolsDiscovery = async () => {};
+
+    await assert.rejects(
+      createPlan(conn, schema).text("Say hello").run(),
+      { message: "Agent session ended without returning a result" }
+    );
+  });
+
+  it("should reject when agent calls return_result with schema-violating input", async () => {
+    const mcpHandler = new McpOverAcpHandler();
+    const sessionHandlers = new Map<string, SessionHandler>();
+
+    let capturedServer: any = null;
+    const origRegister = mcpHandler.register.bind(mcpHandler);
+    mcpHandler.register = (server: any) => {
+      capturedServer = server;
+      origRegister(server);
+    };
+
+    const conn: AgentConnection = {
+      conductor: { shutdown: async () => {} } as any,
+      connection: {
+        initialize: async () => ({
+          protocolVersion: 1,
+          serverInfo: { name: "mock" },
+          capabilities: {},
+        }),
+        newSession: async () => ({ sessionId: "test-session" }),
+        prompt: async () => {
+          if (capturedServer) {
+            // Agent calls return_result with empty object (missing required "message")
+            await capturedServer.handleMethod("tools/call", {
+              name: "return_result",
+              arguments: {},
+            }, { connectionId: "c1", sessionId: "test-session" });
+          }
+          return { stopReason: "end_turn" };
+        },
+      } as any,
+      mcpHandler,
+      sessionHandlers,
+      initialized: false,
+      conductorPromise: Promise.resolve(),
+    };
+
+    mcpHandler.waitForToolsDiscovery = async () => {};
+
+    try {
+      await assert.rejects(
+        createPlan(conn, schema).text("Say hello").run(),
+        (err: Error) => {
+          assert.ok(err instanceof TypeError, "expected TypeError");
+          assert.match(err.message, /missing required field/i);
+          return true;
+        }
+      );
+    } finally {
+      if (capturedServer) mcpHandler.unregister(capturedServer);
+    }
+  });
+
+  it("should only accept the first call to acceptResult (guard against double invocation)", async () => {
+    const mcpHandler = new McpOverAcpHandler();
+    const sessionHandlers = new Map<string, SessionHandler>();
+
+    let capturedServer: any = null;
+    const origRegister = mcpHandler.register.bind(mcpHandler);
+    mcpHandler.register = (server: any) => {
+      capturedServer = server;
+      origRegister(server);
+    };
+
+    const conn: AgentConnection = {
+      conductor: { shutdown: async () => {} } as any,
+      connection: {
+        initialize: async () => ({
+          protocolVersion: 1,
+          serverInfo: { name: "mock" },
+          capabilities: {},
+        }),
+        newSession: async () => ({ sessionId: "test-session" }),
+        prompt: async () => {
+          if (capturedServer) {
+            await capturedServer.handleMethod("tools/call", {
+              name: "return_result",
+              arguments: { message: "Correct!" },
+            }, { connectionId: "c1", sessionId: "test-session" });
+
+            // Second call with wrong data — should be ignored
+            try {
+              await capturedServer.handleMethod("tools/call", {
+                name: "return_result",
+                arguments: { message: "Wrong!" },
+              }, { connectionId: "c1", sessionId: "test-session" });
+            } catch {
+              // Ignore
+            }
+          }
+          return { stopReason: "end_turn" };
+        },
+      } as any,
+      mcpHandler,
+      sessionHandlers,
+      initialized: false,
+      conductorPromise: Promise.resolve(),
+    };
+
+    mcpHandler.waitForToolsDiscovery = async () => {};
 
     try {
       const result = await createPlan(conn, schema)
         .text("Say hello")
         .run() as { message: string };
 
-      assert.strictEqual(result.message, "Hello!");
+      assert.strictEqual(result.message, "Correct!");
     } finally {
-      cleanup();
+      if (capturedServer) mcpHandler.unregister(capturedServer);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds required-field validation in `acceptResult` so that when an agent omits required properties from its result, the library rejects with a clear `TypeError` ("Agent result is missing required field(s): ...") instead of silently resolving with `undefined` values
- Adds protocol-level message tracing via `THINKWELL_TRACE` env var for debugging agent communication issues
- Adds `FAULT_INJECTION` feature flag (disabled in release builds) gating the `THINKWELL_INJECT_REQUIRED_FIELD` env var for testing error UX
- Cleans up greeting example error handling to avoid double stack traces and "Error: Error:" prefix
- Rewrites tool-race tests with realistic mocks that match actual agent request-response semantics

Closes #72.

## Test plan

- [x] `pnpm build` succeeds and strips `FAULT_INJECTION` from release output
- [x] `pnpm build:debug` succeeds with all flags enabled
- [x] `node --test --import tsx packages/thinkwell/src/tool-race.test.ts` — 4 tests pass
- [x] Manual: `THINKWELL_INJECT_REQUIRED_FIELD=bogusField pnpm greeting` (debug build) produces clean single-line error
- [x] Manual: `THINKWELL_TRACE=/tmp/tw-trace pnpm greeting` produces NDJSON trace file

🤖 Generated with [Claude Code](https://claude.com/claude-code)