### PR TITLE
fix(ci): remove invalid secrets check from smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,8 +13,28 @@ on:
   # enable-sigv4 and THINKWELL_AGENT=kiro.
 
 jobs:
+  preflight:
+    name: Check secrets
+    runs-on: ubuntu-latest
+    outputs:
+      has-key: ${{ steps.check.outputs.has-key }}
+    steps:
+      - name: Check for API key
+        id: check
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "has-key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::ANTHROPIC_API_KEY is not configured — skipping smoke tests"
+            echo "has-key=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
   smoke:
     name: Smoke Tests (Claude)
+    needs: preflight
+    if: needs.preflight.outputs.has-key == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   smoke:
     name: Smoke Tests (Claude)
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Removes the job-level `if: ${{ secrets.ANTHROPIC_API_KEY != '' }}` guard from the smoke test workflow. The `secrets` context is not available in job-level `if` expressions for `workflow_dispatch` triggers, causing an HTTP 422 parse error when manually dispatching the workflow.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>