### PR TITLE
fix: force-exit smoke tests and update claude ACP package name

### DIFF
--- a/doc/rfd/smoke-tests.md
+++ b/doc/rfd/smoke-tests.md
@@ -24,7 +24,7 @@ Today the only smoke test is a single manual step in the release runbook: run th
 
 ### Authentication
 
-Thinkwell's `open('claude')` spawns `@zed-industries/claude-agent-acp`, which uses the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`). The Agent SDK supports two authentication methods:
+Thinkwell's `open('claude')` spawns `@agentclientprotocol/claude-agent-acp`, which uses the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`). The Agent SDK supports two authentication methods:
 
 1. **`ANTHROPIC_API_KEY`** — Pay-per-use API billing. Recommended for CI/CD by Anthropic's docs.
 2. **Subscription auth** — Uses credentials from `claude auth login` stored in `~/.claude/`. Works with Pro/Max plans.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "thinkwell-monorepo",
   "private": true,
   "packageManager": "pnpm@9.15.0",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">= 24",
+      "onFail": "error"
+    }
+  },
   "scripts": {
     "build": "tsx scripts/generate-features.ts --mode=release && pnpm -r build",
     "build:debug": "tsx scripts/generate-features.ts --mode=debug && pnpm -r build:debug",

--- a/packages/acp/src/integration.test.ts
+++ b/packages/acp/src/integration.test.ts
@@ -260,7 +260,7 @@ async function manualIntegrationTest() {
   console.log("Starting manual integration test...");
 
   // The agent command - defaults to Claude Code ACP
-  const agentCommand = process.env.AGENT_COMMAND?.split(" ") ?? ["npx", "-y", "@zed-industries/claude-agent-acp"];
+  const agentCommand = process.env.AGENT_COMMAND?.split(" ") ?? ["npx", "-y", "@agentclientprotocol/claude-agent-acp"];
 
   console.log("Using agent command:", agentCommand.join(" "));
 

--- a/packages/thinkwell/package.json
+++ b/packages/thinkwell/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=18"
   },
   "files": [
     "bin",

--- a/packages/thinkwell/package.json
+++ b/packages/thinkwell/package.json
@@ -39,7 +39,7 @@
     "bundle": "tsx scripts/bundle.ts",
     "clean": "rm -rf dist dist-bin dist-pkg",
     "test": "node --test --import tsx src/**/*.test.ts",
-    "test:smoke": "node --test --test-timeout=90000 --import tsx src/integration.test.ts"
+    "test:smoke": "node --test --test-force-exit --test-timeout=90000 --import tsx src/integration.test.ts"
   },
   "keywords": [
     "thinkwell",

--- a/packages/thinkwell/package.json
+++ b/packages/thinkwell/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "files": [
     "bin",

--- a/packages/thinkwell/src/agent.ts
+++ b/packages/thinkwell/src/agent.ts
@@ -42,7 +42,7 @@ export type AgentName = 'claude' | 'codex' | 'gemini' | 'kiro' | 'opencode' | 'a
  * Maps agent names to their spawn commands.
  */
 const AGENT_COMMANDS: Record<AgentName, string> = {
-  claude: "npx -y @zed-industries/claude-agent-acp",
+  claude: "npx -y @agentclientprotocol/claude-agent-acp",
   codex: "npx -y @zed-industries/codex-acp",
   gemini: "npx -y @google/gemini-cli --experimental-acp",
   kiro: "kiro-cli acp",

--- a/packages/thinkwell/src/integration.test.ts
+++ b/packages/thinkwell/src/integration.test.ts
@@ -216,7 +216,7 @@ describe("Thought Stream live integration", { skip: SKIP_LIVE }, () => {
  * 3. Execute and get typed result
  *
  * Environment variables:
- * - AGENT_COMMAND: The agent command (default: "npx -y @zed-industries/claude-agent-acp")
+ * - AGENT_COMMAND: The agent command (default: "npx -y @agentclientprotocol/claude-agent-acp")
  */
 async function manualThinkwellTest() {
   console.log("Starting manual thinkwell integration test...\n");

--- a/website/api/agent.mdx
+++ b/website/api/agent.mdx
@@ -28,7 +28,7 @@ Supported agent names:
 
 | Name | Command |
 |------|---------|
-| `'claude'` | `npx -y @zed-industries/claude-agent-acp` |
+| `'claude'` | `npx -y @agentclientprotocol/claude-agent-acp` |
 | `'codex'` | `npx -y @zed-industries/codex-acp` |
 | `'gemini'` | `npx -y @google/gemini-cli --experimental-acp` |
 | `'kiro'` | `kiro-cli acp` |

--- a/website/get-started/cli.mdx
+++ b/website/get-started/cli.mdx
@@ -281,7 +281,7 @@ If both are set, `THINKWELL_AGENT_CMD` takes precedence.
 
 | Name | Command |
 |------|---------|
-| `claude` | `npx -y @zed-industries/claude-agent-acp` |
+| `claude` | `npx -y @agentclientprotocol/claude-agent-acp` |
 | `codex` | `npx -y @zed-industries/codex-acp` |
 | `gemini` | `npx -y @google/gemini-cli --experimental-acp` |
 | `kiro` | `kiro-cli acp` |


### PR DESCRIPTION
## Summary

- Add `--test-force-exit` to the smoke test script to prevent the Node.js process from hanging after tests complete (background message pump tasks keep the event loop alive, causing the 5-minute CI timeout even though tests finish in ~2 minutes)
- Update `@zed-industries/claude-agent-acp` to `@agentclientprotocol/claude-agent-acp` across source, tests, and documentation

## Test plan

- [ ] Verify smoke tests in CI complete without hitting the 5-minute timeout
- [ ] Verify `npx -y @agentclientprotocol/claude-agent-acp` resolves and launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)