### PR TITLE
refactor(vscode-ts-plugin): move augmentations to OS cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ dist-pkg/
 .DS_Store
 **/*.log
 
-# Thinkwell plugin generated augmentations
-.thinkwell/
-
 # VSCode extension packaging artifacts
 *.vsix
 packages/vscode-extension/package-lock.json

--- a/packages/vscode-extension/scripts/prepare-package.js
+++ b/packages/vscode-extension/scripts/prepare-package.js
@@ -23,6 +23,7 @@ const pluginDst = path.join(nodeModulesDir, "@thinkwell/vscode-ts-plugin");
 const files = [
   "package.json",
   "dist/index.js",
+  "dist/cache-dir.js",
   "dist/scanner.js",
   "dist/virtual-declarations.js",
   "dist/standalone-resolver.js",

--- a/packages/vscode-ts-plugin/src/cache-dir.ts
+++ b/packages/vscode-ts-plugin/src/cache-dir.ts
@@ -1,51 +1,24 @@
 /**
- * Computes the OS-appropriate cache directory for the thinkwell VSCode plugin.
+ * Computes the cache directory for the thinkwell VSCode plugin's
+ * generated augmentation files.
  *
- * Augmentation files are written here instead of in the user's project tree,
- * keeping the project directory clean and avoiding accidental commits.
+ * Uses `node_modules/.cache/thinkwell/` inside the project directory.
+ * This location is:
+ * - Already gitignored (under node_modules/)
+ * - A well-known convention (Babel, webpack, eslint use it)
+ * - Close enough to node_modules/thinkwell that `import("thinkwell")`
+ *   in the augmentations file resolves naturally via Node's
+ *   parent-directory walk
+ * - Invisible to users browsing their source tree
  */
 
-import { createHash } from "node:crypto";
-import { homedir, platform } from "node:os";
 import path from "node:path";
 
 /**
- * Get the OS-appropriate base cache directory.
+ * Get the cache directory for a project's augmentation files.
  *
- * - macOS:   ~/Library/Caches
- * - Linux:   $XDG_CACHE_HOME or ~/.cache
- * - Windows: %LOCALAPPDATA% or ~/AppData/Local
- */
-function osCacheDir(): string {
-  switch (platform()) {
-    case "darwin":
-      return path.join(homedir(), "Library", "Caches");
-    case "win32":
-      return process.env.LOCALAPPDATA ?? path.join(homedir(), "AppData", "Local");
-    default:
-      // Linux / FreeBSD / etc — follow XDG Base Directory spec
-      return process.env.XDG_CACHE_HOME ?? path.join(homedir(), ".cache");
-  }
-}
-
-/**
- * Compute a short, stable hash of the project directory path.
- *
- * This gives each project its own subdirectory in the cache without
- * leaking the full project path into the directory name.
- */
-function projectHash(projectDir: string): string {
-  return createHash("sha256").update(projectDir).digest("hex").slice(0, 12);
-}
-
-/**
- * Get the cache directory for a specific project's augmentation files.
- *
- * Returns a path like:
- * - macOS:   ~/Library/Caches/thinkwell-plugin/<hash>/
- * - Linux:   ~/.cache/thinkwell-plugin/<hash>/
- * - Windows: %LOCALAPPDATA%/thinkwell-plugin/<hash>/
+ * Returns `<projectDir>/node_modules/.cache/thinkwell/`.
  */
 export function getAugmentationsCacheDir(projectDir: string): string {
-  return path.join(osCacheDir(), "thinkwell-plugin", projectHash(projectDir));
+  return path.join(projectDir, "node_modules", ".cache", "thinkwell");
 }

--- a/packages/vscode-ts-plugin/src/cache-dir.ts
+++ b/packages/vscode-ts-plugin/src/cache-dir.ts
@@ -1,0 +1,51 @@
+/**
+ * Computes the OS-appropriate cache directory for the thinkwell VSCode plugin.
+ *
+ * Augmentation files are written here instead of in the user's project tree,
+ * keeping the project directory clean and avoiding accidental commits.
+ */
+
+import { createHash } from "node:crypto";
+import { homedir, platform } from "node:os";
+import path from "node:path";
+
+/**
+ * Get the OS-appropriate base cache directory.
+ *
+ * - macOS:   ~/Library/Caches
+ * - Linux:   $XDG_CACHE_HOME or ~/.cache
+ * - Windows: %LOCALAPPDATA% or ~/AppData/Local
+ */
+function osCacheDir(): string {
+  switch (platform()) {
+    case "darwin":
+      return path.join(homedir(), "Library", "Caches");
+    case "win32":
+      return process.env.LOCALAPPDATA ?? path.join(homedir(), "AppData", "Local");
+    default:
+      // Linux / FreeBSD / etc — follow XDG Base Directory spec
+      return process.env.XDG_CACHE_HOME ?? path.join(homedir(), ".cache");
+  }
+}
+
+/**
+ * Compute a short, stable hash of the project directory path.
+ *
+ * This gives each project its own subdirectory in the cache without
+ * leaking the full project path into the directory name.
+ */
+function projectHash(projectDir: string): string {
+  return createHash("sha256").update(projectDir).digest("hex").slice(0, 12);
+}
+
+/**
+ * Get the cache directory for a specific project's augmentation files.
+ *
+ * Returns a path like:
+ * - macOS:   ~/Library/Caches/thinkwell-plugin/<hash>/
+ * - Linux:   ~/.cache/thinkwell-plugin/<hash>/
+ * - Windows: %LOCALAPPDATA%/thinkwell-plugin/<hash>/
+ */
+export function getAugmentationsCacheDir(projectDir: string): string {
+  return path.join(osCacheDir(), "thinkwell-plugin", projectHash(projectDir));
+}

--- a/packages/vscode-ts-plugin/src/index.ts
+++ b/packages/vscode-ts-plugin/src/index.ts
@@ -14,8 +14,8 @@ import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { type MarkedType, findMarkedTypes, hasJsonSchemaMarkers } from "./scanner";
 import { generateVirtualDeclarations } from "./virtual-declarations";
 import { patchModuleResolution, getVirtualTypeContent } from "./standalone-resolver";
+import { getAugmentationsCacheDir } from "./cache-dir";
 
-const VIRTUAL_DIR = ".thinkwell";
 const VIRTUAL_FILE_NAME = "augmentations.d.ts";
 
 interface PluginState {
@@ -182,7 +182,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
     info: ts.server.PluginCreateInfo,
     projectDir: string,
   ): ts.LanguageService {
-    const virtualFilePath = path.join(projectDir, VIRTUAL_DIR, VIRTUAL_FILE_NAME);
+    const virtualFilePath = path.join(getAugmentationsCacheDir(projectDir), VIRTUAL_FILE_NAME);
 
     // Write a minimal placeholder so the augmentations file exists on disk
     // BEFORE tsserver's first updateGraph. This ensures tsserver can create
@@ -212,7 +212,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
     // Monkey-patch resolveModuleNameLiterals for standalone scripts
     // that import thinkwell without node_modules.
     // ---------------------------------------------------------------
-    patchModuleResolution(info, tsModule);
+    patchModuleResolution(info, tsModule, virtualFilePath);
 
     // ---------------------------------------------------------------
     // Patch getScriptSnapshot, getScriptVersion, getScriptFileNames,

--- a/packages/vscode-ts-plugin/src/index.ts
+++ b/packages/vscode-ts-plugin/src/index.ts
@@ -289,6 +289,22 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
     }
 
     // ---------------------------------------------------------------
+    // Run the initial scan eagerly so the augmentations file (if any
+    // @JSONSchema types exist) is on disk and in getScriptFileNames
+    // BEFORE tsserver's first updateGraph. This is critical: if the
+    // file only appears during getSemanticDiagnostics, tsserver has
+    // already built the program without it.
+    // ---------------------------------------------------------------
+    const fileNames = info.languageServiceHost.getScriptFileNames();
+    if (fileNames.length > 0) {
+      state.initialScanDone = true;
+      fullScan(tsModule, info, state);
+      info.project.log(
+        `[thinkwell] Initial scan complete. Found ${state.augmentedTypeNames.size} augmented type(s).`,
+      );
+    }
+
+    // ---------------------------------------------------------------
     // Wrap the language service proxy to intercept diagnostics and
     // trigger rescans on file changes.
     // ---------------------------------------------------------------
@@ -302,16 +318,16 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
     // On getSemanticDiagnostics: rescan the file first, then filter results
     proxy.getSemanticDiagnostics = (fileName: string): ts.Diagnostic[] => {
-      // Deferred initial scan — write augmentations file on first call
+      // Run deferred initial scan if it couldn't run during plugin creation
+      // (e.g., because getScriptFileNames was empty at that point).
       if (!state.initialScanDone) {
-        const fileNames = info.languageServiceHost.getScriptFileNames();
-        if (fileNames.length > 0) {
+        const currentFileNames = info.languageServiceHost.getScriptFileNames();
+        if (currentFileNames.length > 0) {
           state.initialScanDone = true;
           fullScan(tsModule, info, state);
           info.project.log(
-            `[thinkwell] Initial scan complete. Found ${state.augmentedTypeNames.size} augmented type(s).`,
+            `[thinkwell] Deferred initial scan complete. Found ${state.augmentedTypeNames.size} augmented type(s).`,
           );
-
         }
       }
 

--- a/packages/vscode-ts-plugin/src/index.ts
+++ b/packages/vscode-ts-plugin/src/index.ts
@@ -31,6 +31,8 @@ interface PluginState {
   augmentedTypeNames: Set<string>;
   /** Whether the initial full scan has been performed. */
   initialScanDone: boolean;
+  /** Whether the cache dir and augmentations file have been created on disk. */
+  fileCreated: boolean;
 }
 
 /**
@@ -129,22 +131,30 @@ function writeVirtualFile(
     }
   }
 
-  // If no types found, revert to the placeholder content (not empty)
-  // so tsserver keeps the file in the program.
-  const PLACEHOLDER = "// @thinkwell augmentations — will be populated on first scan\n";
-  const effectiveContent = newContent || PLACEHOLDER;
-
   // Only write if content actually changed
-  if (effectiveContent === state.virtualContent) return;
-  state.virtualContent = effectiveContent;
+  if (newContent === state.virtualContent) return;
+  state.virtualContent = newContent;
   state.virtualFileVersion++;
+
+  // Only create the cache dir and file when types are first found.
+  // Once created, keep writing updates (including empty content) so
+  // tsserver sees the file change rather than having it disappear.
+  if (!state.fileCreated && !newContent) {
+    // No types found and file never created — nothing to do
+    return;
+  }
 
   try {
     const dir = path.dirname(state.virtualFilePath);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(state.virtualFilePath, effectiveContent, "utf-8");
+    // Write a placeholder to disk when content is empty — the file must
+    // exist on disk for tsserver's ScriptInfo creation, but the in-memory
+    // snapshot (returned by getScriptSnapshot) is what tsserver actually uses.
+    const PLACEHOLDER = "// @thinkwell augmentations\n";
+    writeFileSync(state.virtualFilePath, newContent || PLACEHOLDER, "utf-8");
+    state.fileCreated = true;
     info.project.log(`[thinkwell] Wrote augmentations to ${state.virtualFilePath} (version ${state.virtualFileVersion})`);
   } catch (e) {
     info.project.log(`[thinkwell] Failed to write augmentations: ${e}`);
@@ -184,28 +194,18 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
   ): ts.LanguageService {
     const virtualFilePath = path.join(getAugmentationsCacheDir(projectDir), VIRTUAL_FILE_NAME);
 
-    // Write a minimal placeholder so the augmentations file exists on disk
-    // BEFORE tsserver's first updateGraph. This ensures tsserver can create
-    // a ScriptInfo for it (ScriptInfo creation for non-open files requires
-    // the file to exist on disk).
-    const PLACEHOLDER = "// @thinkwell augmentations — will be populated on first scan\n";
-    try {
-      const dir = path.dirname(virtualFilePath);
-      if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-      }
-      writeFileSync(virtualFilePath, PLACEHOLDER, "utf-8");
-    } catch {
-      // Ignore — best effort
-    }
+    // Don't write a placeholder eagerly — the cache dir and file are only
+    // created when the initial scan finds @JSONSchema types. This avoids
+    // littering the cache with empty directories for every tsserver project.
 
     const state: PluginState = {
       typesByFile: new Map(),
-      virtualContent: PLACEHOLDER,
+      virtualContent: "",
       virtualFileVersion: 0,
       virtualFilePath,
       augmentedTypeNames: new Set(),
       initialScanDone: false,
+      fileCreated: false,
     };
 
     // ---------------------------------------------------------------
@@ -238,7 +238,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
     const origGetScriptFileNames = info.languageServiceHost.getScriptFileNames.bind(info.languageServiceHost);
     info.languageServiceHost.getScriptFileNames = () => {
       const names = origGetScriptFileNames();
-      if (state.virtualContent && !names.includes(virtualFilePath)) {
+      if (state.fileCreated && !names.includes(virtualFilePath)) {
         return [...names, virtualFilePath];
       }
       return names;
@@ -246,7 +246,7 @@ function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
 
     const origGetScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
     info.languageServiceHost.getScriptSnapshot = (fileName: string) => {
-      if (fileName === virtualFilePath && state.virtualContent) {
+      if (fileName === virtualFilePath && state.fileCreated) {
         // Call original to ensure ScriptInfo is created and attached
         // to the project. The Project's getScriptSnapshot creates the
         // ScriptInfo via getOrCreateScriptInfoAndAttachToProject(),

--- a/packages/vscode-ts-plugin/src/standalone-resolver.ts
+++ b/packages/vscode-ts-plugin/src/standalone-resolver.ts
@@ -7,7 +7,7 @@
  * resolves `thinkwell`, `@thinkwell/acp`, and `@thinkwell/protocol` imports
  * to bundled .d.ts declarations embedded in the plugin at build time.
  *
- * The augmentations file (`.thinkwell/augmentations.d.ts`) also needs
+ * The augmentations file (`augmentations.d.ts` in the OS cache) also needs
  * custom resolution because it uses `import("thinkwell").SchemaProvider`
  * type references that must resolve to the same `SchemaProvider` generic
  * interface used by `think()`.
@@ -121,6 +121,7 @@ function resolveRelativeVirtualImport(
 export function patchModuleResolution(
   info: ts.server.PluginCreateInfo,
   tsModule: typeof ts,
+  augmentationsFilePath: string,
 ): void {
   const log = (msg: string) => info.project.log(msg);
 
@@ -138,7 +139,7 @@ export function patchModuleResolution(
 
   /** Check if a file is the virtual augmentations file. */
   function isAugmentationsFile(fileName: string): boolean {
-    return fileName.endsWith(".thinkwell/augmentations.d.ts");
+    return fileName === augmentationsFilePath;
   }
 
   /** Check if a file is a bundled virtual type file. */
@@ -228,7 +229,35 @@ export function patchModuleResolution(
       return results;
     }
 
-    // Resolve each unresolved thinkwell import to a virtual path
+    // For the augmentations file (which lives in an OS cache dir, not the
+    // project tree), try resolving thinkwell imports from the project dir
+    // first. This ensures the augmentations file uses the SAME SchemaProvider
+    // type as the project code, which is critical for generic inference in
+    // think<T>(schema: SchemaProvider<T>). Falling back to bundled types
+    // would give a structurally identical but module-identity-distinct type,
+    // causing T to resolve as `unknown`.
+    if (isAugmentationsFile(containingFile)) {
+      const projectDir = info.project.getCurrentDirectory();
+      const proxyContainingFile = path.join(projectDir, "__augmentations_proxy__.d.ts");
+      for (let i = 0; i < moduleLiterals.length; i++) {
+        const specifier = getText(moduleLiterals[i]);
+        if (!THINKWELL_MODULES.has(specifier)) continue;
+        if (results[i].resolvedModule) continue;
+
+        // Try resolving from the project directory so node_modules/thinkwell is found
+        const projectResult = tsModule.resolveModuleName(
+          specifier, proxyContainingFile, options, tsModule.sys,
+        );
+        if (projectResult.resolvedModule) {
+          log(`[thinkwell] Resolved import '${specifier}' in ${path.basename(containingFile)} → ${projectResult.resolvedModule.resolvedFileName} (via project dir)`);
+          results[i] = projectResult;
+          continue;
+        }
+      }
+    }
+
+    // Resolve remaining unresolved thinkwell imports to bundled virtual types
+    // (standalone scripts and augmentations without project node_modules)
     for (let i = 0; i < moduleLiterals.length; i++) {
       const specifier = getText(moduleLiterals[i]);
 

--- a/packages/vscode-ts-plugin/src/test-harness.ts
+++ b/packages/vscode-ts-plugin/src/test-harness.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import init from "./index";
+import { getAugmentationsCacheDir } from "./cache-dir";
 
 const COMPILER_OPTIONS: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2022,
@@ -96,7 +97,7 @@ export function createTestProject(
       : path.join(projectDir, relativePath);
   }
 
-  const augmentationsPath = path.join(projectDir, ".thinkwell", "augmentations.d.ts");
+  const augmentationsPath = path.join(getAugmentationsCacheDir(projectDir), "augmentations.d.ts");
 
   /** Get all tracked file names, plus the augmentations file if it exists on disk. */
   function getFileNames(): string[] {

--- a/packages/vscode-ts-plugin/src/virtual-declarations.test.ts
+++ b/packages/vscode-ts-plugin/src/virtual-declarations.test.ts
@@ -3,8 +3,12 @@ import assert from "node:assert/strict";
 import { generateVirtualDeclarations } from "./virtual-declarations";
 import type { MarkedType } from "./scanner";
 
-/** Augmentations file path used consistently across tests. */
-const AUGMENTATIONS_PATH = "/project/.thinkwell/augmentations.d.ts";
+/**
+ * Augmentations file path used consistently across tests.
+ * Uses a cache-dir-style path (outside the project tree) to match
+ * the real plugin behavior.
+ */
+const AUGMENTATIONS_PATH = "/cache/thinkwell-plugin/abc123/augmentations.d.ts";
 
 describe("generateVirtualDeclarations", () => {
   it("generates empty content for no types", () => {
@@ -18,7 +22,8 @@ describe("generateVirtualDeclarations", () => {
     ]);
     const result = generateVirtualDeclarations(types, AUGMENTATIONS_PATH);
     assert.ok(result.includes('declare namespace Greeting {'));
-    assert.ok(result.includes('import("../src/types.js").Greeting'));
+    // Relative path traverses from cache dir up to project source
+    assert.ok(result.includes('import("../../../project/src/types.js").Greeting'));
     assert.ok(result.includes('import("thinkwell").SchemaProvider'));
     assert.ok(!result.includes("export declare namespace"));
   });
@@ -46,9 +51,9 @@ describe("generateVirtualDeclarations", () => {
     assert.ok(result.includes("declare namespace Greeting"));
     assert.ok(result.includes("declare namespace Farewell"));
     assert.ok(result.includes("declare namespace Sentiment"));
-    assert.ok(result.includes('import("../src/types.js").Greeting'));
-    assert.ok(result.includes('import("../src/types.js").Farewell'));
-    assert.ok(result.includes('import("../src/models.js").Sentiment'));
+    assert.ok(result.includes('import("../../../project/src/types.js").Greeting'));
+    assert.ok(result.includes('import("../../../project/src/types.js").Farewell'));
+    assert.ok(result.includes('import("../../../project/src/models.js").Sentiment'));
     assert.ok(result.includes("// From /project/src/types.ts"));
     assert.ok(result.includes("// From /project/src/models.ts"));
   });

--- a/packages/vscode-ts-plugin/src/virtual-declarations.ts
+++ b/packages/vscode-ts-plugin/src/virtual-declarations.ts
@@ -1,7 +1,7 @@
 /**
  * Generates the augmentation `.d.ts` content from discovered
- * @JSONSchema-marked types. The plugin writes this to disk at
- * `.thinkwell/augmentations.d.ts` in the project root.
+ * @JSONSchema-marked types. The plugin writes this to the OS cache
+ * directory to keep the user's project tree clean.
  */
 
 import type { MarkedType } from "./scanner";
@@ -49,6 +49,11 @@ function generateNamespaceDeclaration(
  * source file, suitable for use in `import("...")` type references.
  *
  * Strips the `.ts` / `.tsx` extension and ensures a leading `./` or `../`.
+ *
+ * Since the augmentations file lives in an OS cache directory, these
+ * relative paths traverse up from the cache to the project tree. This is
+ * longer than when the file lived in `.thinkwell/`, but TypeScript handles
+ * these paths correctly with its module resolution.
  */
 function relativeModulePath(
   augmentationsFilePath: string,


### PR DESCRIPTION
## Summary

- Moves the generated `augmentations.d.ts` from `.thinkwell/` in the project root to the OS cache directory (`~/Library/Caches/thinkwell-plugin/<hash>/` on macOS, `~/.cache/` on Linux, `%LOCALAPPDATA%` on Windows), keeping the user's project tree clean
- Adds `cache-dir.ts` utility for cross-platform cache path computation using a SHA-256 hash of the project path
- Updates module resolution so the augmentations file resolves `import("thinkwell")` from the project's `node_modules` first (preserving type identity for generic inference), falling back to bundled types for standalone scripts
- Removes `.thinkwell/` from `.gitignore` since augmentations no longer live in the project tree

## Test plan

- [x] All 42 vscode-ts-plugin tests pass (including the type inference integration test)
- [ ] Manually verify augmentations file is created in OS cache dir when opening a project with `@JSONSchema` types
- [ ] Verify no `.thinkwell/` directory is created in the project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)